### PR TITLE
Improve setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Source of [docs.fivem.net][docs].
 Development
 -----------
 
-Install [Hugo][gohugo], then run:
+Install [Hugo][gohugo] *0.49*, then run:
 
 ```sh
 git submodule init


### PR DESCRIPTION
Specify theme supported version of hugo - 0.49 - as theme relies on *Source* struct that was removed in 0.50

See https://github.com/vjeantet/hugo-theme-docdock/issues/166