### PR TITLE
Error when sample code is executed with shorthand property initializer

### DIFF
--- a/content/scripting-manual/runtimes/javascript.md
+++ b/content/scripting-manual/runtimes/javascript.md
@@ -96,7 +96,7 @@ const root = GetResourcePath(GetCurrentResourceName());
 // wrong
 fs.readFile(`${root}/test.txt`, { encoding: 'utf8' }, (err, data) => {
   emit('chat:addMessage', { // this call will error out due to thread affinity
-    args = [ data ]
+    args: [ data ]
   });
 });
 
@@ -104,7 +104,7 @@ fs.readFile(`${root}/test.txt`, { encoding: 'utf8' }, (err, data) => {
 fs.readFile(`${root}/test.txt`, { encoding: 'utf8' }, (err, data) => {
   setImmediate(() => { // the callback will be called next game tick
     emit('chat:addMessage', {
-      args = [ data ]
+      args: [ data ]
     });
   });
 });


### PR DESCRIPTION
The current code (provided by cfx): 
```js
fs.readFile(`${root}/test.txt`, { encoding: 'utf8' }, (err, data) => {
  setImmediate(() => { // the callback will be called next game tick
    emit('chat:addMessage', {
// below will not work
      args = [ data ]
// below will work
     args: [data]
    });
  });
});
```
>will throw an error `Invalid shorthand property initializer` due to javascript properties.
https://gyazo.com/83caf81ca5a3a29b4a5383711ace51dd

> when I change the code to the working part, the code runs w/ no errors.
https://gyazo.com/a4da10daeb6df5d13b58e971d2127625