### PR TITLE
Add a section that provides instructions on migrating from deprecated methods to newer methods...

### DIFF
--- a/content/scripting-manual/_index.md
+++ b/content/scripting-manual/_index.md
@@ -18,3 +18,5 @@ weight: 400
 <!--    - [Creating new events](/scripting-manual/working-with-event/creating-new-events) -->
 <!--    - [Server-client communication](/scripting-manual/working-with-event/server-client-communication) -->
 - [Using Scaleform](/scripting-manual/using-scaleform)
+- [Migrating from deprecated methods](/scripting-manual/migrating-from-deprecated)
+  - [Chat Messages](/scripting-manual/migrating-from-deprecated/chat-messages)

--- a/content/scripting-manual/migrating-from-deprecated/_index.md
+++ b/content/scripting-manual/migrating-from-deprecated/_index.md
@@ -1,0 +1,10 @@
+---
+title: Migrating from deprecated methods
+weight: 430
+---
+
+In the past few years, FiveM has developed and advanced vastly. As a result of this, many tutorials and scripts have been left behind with methods and whatnot. This section will provide instructions on how to change from methods that have been deprecated.
+
+- [Chat Messages](scripting/migrating-from-deprecated/chat-messages)
+- [Creating Commands](scripting/migrating-from-deprecated/creating-commands)
+  

--- a/content/scripting-manual/migrating-from-deprecated/_index.md
+++ b/content/scripting-manual/migrating-from-deprecated/_index.md
@@ -5,6 +5,6 @@ weight: 430
 
 In the past few years, FiveM has developed and advanced vastly. As a result of this, many tutorials and scripts have been left behind with methods and whatnot. This section will provide instructions on how to change from methods that have been deprecated.
 
-- [Chat Messages](scripting/migrating-from-deprecated/chat-messages)
-- [Creating Commands](scripting/migrating-from-deprecated/creating-commands)
+- [Chat Messages](chat-messages)
+- [Creating Commands](creating-commands)
   

--- a/content/scripting-manual/migrating-from-deprecated/chat-messages.md
+++ b/content/scripting-manual/migrating-from-deprecated/chat-messages.md
@@ -1,0 +1,26 @@
+---
+title: Creating chat messages
+weight: 431
+---
+
+Commonly found in tutorials and older resources, the `chatMessage` event is used to create a chat message. This method is now deprecated and people are encouraged to use the `chat:addMessage` event.
+
+## chatMessage (The deprecated method)
+The old `chatMessage` event had 3 parameters (`author`[string], `color`[array] and `text`[string])
+
+### Example
+```lua
+TriggerEvent("chatMessage", GetPlayerName(PlayerId()), {255, 255, 255}, "Hello, this is the message that will show in chat.")
+```
+
+## `chat:addMessage` (The recommended method)
+This event has an object parameter which consists of 3 properties (`color`[array], `multiline`[boolean], `args`[array])
+
+### Example
+```lua
+TriggerEvent("chat:addMessage", {
+    color = {255, 255, 255},
+    multiline = true,
+    args = { GetPlayerName(PlayerId()), "Hello, this is the message that will show in chat" }
+})
+```

--- a/content/scripting-manual/migrating-from-deprecated/chat-messages.md
+++ b/content/scripting-manual/migrating-from-deprecated/chat-messages.md
@@ -14,7 +14,7 @@ TriggerEvent("chatMessage", GetPlayerName(PlayerId()), {255, 255, 255}, "Hello, 
 ```
 
 ## `chat:addMessage` (The recommended method)
-This event has an object parameter which consists of 3 properties (`color`[array], `multiline`[boolean], `args`[array])
+This event has an object parameter which consists of 3 properties (`color`[array], `multiline`[boolean] and `args`[array])
 
 ### Example
 ```lua

--- a/content/scripting-manual/migrating-from-deprecated/chat-messages.md
+++ b/content/scripting-manual/migrating-from-deprecated/chat-messages.md
@@ -24,3 +24,5 @@ TriggerEvent("chat:addMessage", {
     args = { GetPlayerName(PlayerId()), "Hello, this is the message that will show in chat" }
 })
 ```
+
+For further documentation of this event, see the [`chat:addMessage` section](../../../resources/chat/events/chat-addMessage).

--- a/content/scripting-manual/migrating-from-deprecated/creating-commands.md
+++ b/content/scripting-manual/migrating-from-deprecated/creating-commands.md
@@ -1,0 +1,7 @@
+---
+title: Creating commands
+weight: 432
+---
+
+## The `chatMessage` method
+In the past, people have used the `chatMessage` event to detect when a chat message is being sent. After that, they would use a string split method to see if the first argument in that table (of split strings) contained a command.

--- a/content/scripting-manual/migrating-from-deprecated/creating-commands.md
+++ b/content/scripting-manual/migrating-from-deprecated/creating-commands.md
@@ -5,3 +5,30 @@ weight: 432
 
 ## The `chatMessage` method
 In the past, people have used the `chatMessage` event to detect when a chat message is being sent. After that, they would use a string split method to see if the first argument in that table (of split strings) contained a command.
+
+### Example
+```lua
+AddEventHandler("chatMessage", function(source, name, message)
+    if string.sub(message, 1, 1) == "/" then
+        sm = stringsplit(message, " ")
+        if sm[1] == "/command" then
+            print("Command was entered.")
+        end
+    end
+end)
+
+function stringsplit(inputstr, sep)
+    if sep == nil then
+        sep = "%s"
+    end
+
+    local t = {}
+    for str in string.gmatch(inputstr, "([^" .. sep .. "]+)") do
+        t[i] = str
+        i = i + 1
+    end
+    return t
+end
+```
+
+## The [`RegisterCommand()`](https://runtime.fivem.net/doc/natives/#_0x5FA79B0F) -- which you should always be using

--- a/content/scripting-manual/migrating-from-deprecated/creating-commands.md
+++ b/content/scripting-manual/migrating-from-deprecated/creating-commands.md
@@ -44,3 +44,5 @@ RegisterCommand("commandName", function(source --[[ this is the player ID: a num
     end
 end, true) -- this true bool means that the user cannot execute the command unless they have the 'command.commandName' ace allowed to one of their identifiers.
 ```
+
+Further examples can be found at the respective [Lua](../../introduction/creating-your-first-script) and [C#](../../introduction/creating-your-first-script-csharp) introductions.

--- a/content/scripting-manual/migrating-from-deprecated/creating-commands.md
+++ b/content/scripting-manual/migrating-from-deprecated/creating-commands.md
@@ -3,7 +3,7 @@ title: Creating commands
 weight: 432
 ---
 
-## The `chatMessage` method
+## The `chatMessage` method (deprecated)
 In the past, people have used the `chatMessage` event to detect when a chat message is being sent. After that, they would use a string split method to see if the first argument in that table (of split strings) contained a command.
 
 ### Example
@@ -32,7 +32,7 @@ end
 ```
 
 ## The [`RegisterCommand()`](https://runtime.fivem.net/doc/natives/#_0x5FA79B0F) -- which you should always be using
-This is a somewhat recent addition to the CFX natives, it is recommended to use this as it allow for the use of the integrated ace permissions system. This native consists of 3 parameters (`commandName`[string], `handler`[func] and `restricted`[boolean]).
+This is a somewhat recent addition to the CFX natives, it is recommended to use this as it allows for the use of the integrated ACE permissions system. This native consists of 3 parameters (`commandName`[string], `handler`[func] and `restricted`[boolean]).
 
 ### Example
 ```lua

--- a/content/scripting-manual/migrating-from-deprecated/creating-commands.md
+++ b/content/scripting-manual/migrating-from-deprecated/creating-commands.md
@@ -11,7 +11,7 @@ In the past, people have used the `chatMessage` event to detect when a chat mess
 AddEventHandler("chatMessage", function(source, name, message)
     if string.sub(message, 1, 1) == "/" then
         sm = stringsplit(message, " ")
-        if sm[1] == "/command" then
+        if sm[1] == "/commandName" then
             print("Command was entered.")
         end
     end
@@ -32,3 +32,15 @@ end
 ```
 
 ## The [`RegisterCommand()`](https://runtime.fivem.net/doc/natives/#_0x5FA79B0F) -- which you should always be using
+This is a somewhat recent addition to the CFX natives, it is recommended to use this as it allow for the use of the integrated ace permissions system. This native consists of 3 parameters (`commandName`[string], `handler`[func] and `restricted`[boolean]).
+
+### Example
+```lua
+RegisterCommand("commandName", function(source --[[ this is the player ID: a number ]], args --[[ this is a table of the arguments provided ]], rawCommand --[[ this is what the user entered]])
+    if source > 0 then
+        print("You are not console.")
+    else
+        print("This is console!")
+    end
+end, true) -- this true bool means that the user cannot execute the command unless they have the 'command.commandName' ace allowed to one of their identifiers.
+```


### PR DESCRIPTION
Currently, this only documents the two _main_ deprecated/out-of-date methods I've seen. Those being the `chatMessage` event for sending chat messages, and the `chatMessage` event for detecting commands.