### PR TITLE
events/list/playerDropped: Removed "source" from function definition

### DIFF
--- a/content/scripting-reference/events/list/playerDropped.md
+++ b/content/scripting-reference/events/list/playerDropped.md
@@ -20,7 +20,8 @@ Examples
 This example prints the name of the player and the reason why the player has disconnected to the server console.
 ##### Lua Example:
 ```lua
-AddEventHandler('playerDropped', function (source, reason)
+-- source is global here, don't add to function
+AddEventHandler('playerDropped', function (reason)
   print('Player ' .. GetPlayerName(source) .. ' dropped (Reason: ' .. reason .. '')
 end)
 ```


### PR DESCRIPTION
This is a global variable in the server script and makes the example not work.