### PR TITLE
Fix the new 'migrating from deprecated methods' opening in a new tab

### DIFF
--- a/content/scripting-manual/migrating-from-deprecated/_index.md
+++ b/content/scripting-manual/migrating-from-deprecated/_index.md
@@ -5,6 +5,6 @@ weight: 430
 
 In the past few years, FiveM has developed and advanced vastly. As a result of this, many tutorials and scripts have been left behind with methods and whatnot. This section will provide instructions on how to change from methods that have been deprecated.
 
-- [Chat Messages](chat-messages)
-- [Creating Commands](creating-commands)
+- [Chat Messages](/scripting-manual/migrating-from-deprecated/chat-messages)
+- [Creating Commands](/scripting-manual/migrating-from-deprecated/creating-commands)
   


### PR DESCRIPTION
The expected behaviour for this is that it redirects the current tab to the location requested. But because I didn't use the methods that other places do, it created this bug. 