### PR TITLE
events: add some examples for other examples and fix some issues

### DIFF
--- a/content/scripting-reference/events/list/onClientResourceStart.md
+++ b/content/scripting-reference/events/list/onClientResourceStart.md
@@ -31,7 +31,7 @@ end)
 ##### C\# Example:
 ```csharp
 // In class constructor
-Eventhandlers["onClientResourceStart"] += new Action<string>(OnClientResourceStart);
+EventHandlers["onClientResourceStart"] += new Action<string>(OnClientResourceStart);
 
 // Delegate method
 // - assuming `using static CitizenFX.Core.Native.API`

--- a/content/scripting-reference/events/list/onClientResourceStop.md
+++ b/content/scripting-reference/events/list/onClientResourceStop.md
@@ -16,7 +16,7 @@ string resourceName
 
 Examples
 --------
-This example prints the name of a resource that was just stopped.
+This example prints the name of the resource that was just stopped.
 
 ##### Lua Example:
 ```lua
@@ -28,7 +28,7 @@ end)
 ##### C\# Example:
 ```csharp
 // In class constructor
-Eventhandlers["onClientResourceStop"] += new Action<string>(OnClientResourceStop);
+EventHandlers["onClientResourceStop"] += new Action<string>(OnClientResourceStop);
 
 // Delegate method
 private void OnClientResourceStop(string resourceName)

--- a/content/scripting-reference/events/list/onResourceStart.md
+++ b/content/scripting-reference/events/list/onResourceStart.md
@@ -16,6 +16,30 @@ string resourceName
 
 Examples
 --------
+This example prints the name of the current resource, upon start.
+
+##### Lua Example:
+```lua
+AddEventHandler('onResourceStart', function(resourceName)
+  if (GetCurrentResourceName() ~= resourceName) then
+    return
+  end
+  print('The resource ' .. resourceName .. ' has been started.')
+end)
+```
+
+##### C\# Example:
+```csharp
+// in the class constructor
+EventHandlers["onResourceStart"] += new Action<string>(OnResourceStart);
+
+// delegate method
+private void OnResourceStart(string resourceName)
+{
+  if (GetCurrentResourceName() != resourceName) return;
+
+  Debug.WriteLine($"The resource {resourceName} has been started.");
+}
 
 ##### JavaScript Example:
 ```js

--- a/content/scripting-reference/events/list/onResourceStop.md
+++ b/content/scripting-reference/events/list/onResourceStop.md
@@ -16,6 +16,31 @@ string resourceName
 
 Examples
 --------
+This example prints the name of the current resource, when stopped.
+
+##### Lua Example:
+```lua
+AddEventHandler('onResourceStop', function(resourceName)
+  if (GetCurrentResourceName() ~= resourceName) then
+    return
+  end
+  print('The resource ' .. resourceName .. ' was stopped.')
+end)
+```
+
+##### C\# Example:
+```csharp
+// in the class constructor
+EventHandlers["onResourceStop"] += new Action<string>(OnResourceStop);
+
+// delegate method
+private void OnResourceStop(string resourceName)
+{
+  if(GetCurrentResourceName() != resourceName) return;
+
+  Debug.WriteLine($"The resource {resourceName} was stopped.");
+}
+```
 
 ##### JavaScript Example:
 ```js

--- a/content/scripting-reference/events/list/playerConnecting.md
+++ b/content/scripting-reference/events/list/playerConnecting.md
@@ -29,7 +29,7 @@ This example checks a connecting player's license identifier against a ban list.
 ##### C\# Example:
 ```csharp
 // In class constructor
-Eventhandlers["playerConnecting"] += new Action<Player, string, dynamic, dynamic>(OnPlayerConnecting);
+EventHandlers["playerConnecting"] += new Action<Player, string, dynamic, dynamic>(OnPlayerConnecting);
 
 // Delegate method
 private void OnPlayerConnecting([FromSource]Player player, string playerName, dynamic setKickReason, dynamic deferrals)


### PR DESCRIPTION
This PR adds some examples in Lua and C# for the `onResourceStart` and `onResourceStop` events. In addition, this also fixes some C# examples for other events as there was a typo with `EventHandlers`.