### PR TITLE
server-installation: Fix the ambiguity in some of the steps

### DIFF
--- a/content/server-manual/setting-up-a-server.md
+++ b/content/server-manual/setting-up-a-server.md
@@ -39,16 +39,16 @@ Windows
 
 Linux
 -----
-1. Create a new folder (for example `mkdir /home/username/server`).
+1. Create a new folder (for example `mkdir /home/username/FXServer/server`), this will be used for the server binaries.
 2. Download the latest `master` branch build for Linux from the [artifacts server][linux-artifacts](copy the URL for the latest server version and use `wget <url>` to download it).
-3. Extract the build using `cd path/to/server/folder && tar xf fx.tar.xz` (you need to have `xz` installed, on Debian/Ubuntu this is in the `xz-utils` package).
-4. Clone [cfx-server-data][server-data] in a new folder (other than your FXServer folder).
-  <br>4b. For example `git clone https://github.com/citizenfx/cfx-server-data.git /home/username/server-data`
+3. Extract the build to the directory that was previously created, using `cd /home/username/FXServer/server && tar xf fx.tar.xz` (you need to have `xz` installed, on Debian/Ubuntu this is in the `xz-utils` package).
+4. Clone [cfx-server-data][server-data] in a new folder outside of your server binaries folder.
+  <br>4b. For example `git clone https://github.com/citizenfx/cfx-server-data.git /home/username/FXServer/server-data`
 5. Make a **server.cfg** file in your `server-data` folder (copy the [example server.cfg](#servercfgexample) file below into that file).
 6. Generate a license key at <https://keymaster.fivem.net>.
 7. Set the license key in your `server.cfg` using `sv_licenseKey "licenseKeyGoesHere"`.
 8. Run the server from the `server-data` folder.
-  <br>8b. `bash /home/username/server/run.sh +exec server.cfg`
+  <br>8b. `bash /home/username/FXServer/server/run.sh +exec server.cfg`
 
 Common issues
 ---------------

--- a/content/server-manual/setting-up-a-server.md
+++ b/content/server-manual/setting-up-a-server.md
@@ -18,11 +18,11 @@ Windows
 2. [Git][git-scm] to assure a correct installation.
 
 #### Installation
-1. Create a new folder (for example `D:\FXServer`).
+1. Create a new directory (for example `D:\FXServer\server`), this will be used for the server binaries.
 2. Download the latest `master` branch build for Windows from the [artifacts server][windows-artifacts].
-3. Extract the build.
+3. Extract the build into the directory previously created.
   <br>3b. Use any archiving tool (such as WinRAR or 7-Zip).
-4. Clone [cfx-server-data][server-data] in a new folder (outside of your FXServer folder).
+4. Clone [cfx-server-data][server-data] in a new folder outside of your server binaries folder, for example, `D:\FXServer\server-data`.
   <br>4b. `git clone https://github.com/citizenfx/cfx-server-data.git server-data`
 5. Make a **server.cfg** file in your `server-data` folder (copy the [example server.cfg](#servercfgexample) file below into that file).
 6. Generate a license key at <https://keymaster.fivem.net>.


### PR DESCRIPTION
I felt as if some of these steps needed further clarification to make sense with the steps mentioned later on in the guide, some wording improvements were added and changing the directory for the example