### PR TITLE
Clarify what is passed as killerid when run over

### DIFF
--- a/content/docs/resources/baseevents/events/onPlayerKilled.md
+++ b/content/docs/resources/baseevents/events/onPlayerKilled.md
@@ -15,7 +15,7 @@ Parameters
 player killerID, array deathData
 ```
 
-- **killerID**: The Client ID of the player who killed the player.
+- **killerID**: The Client ID of the player who killed the player or -1 if the player was run over by a vehicle (even if a player was driving it).
 - **deathData**: An array containing the following things:
     - **(int) killerType**: The pedType of the ped who killed the player. (see screenshot below for the possible pedType values.)
     - **(hash) weaponHash**: The hash of the weapon which was used to kill the player.


### PR DESCRIPTION
For some reason if you are run over by an NPC or player the killerid is -1