### PR TITLE
Updated C# runtime native reference documentation links

### DIFF
--- a/content/docs/scripting-reference/runtimes/csharp/client-functions.md
+++ b/content/docs/scripting-reference/runtimes/csharp/client-functions.md
@@ -9,6 +9,4 @@ There's a few ways to easily tell what functions exist in C# pending manual docu
 1.  You can use Visual Studio's IntelliSense functionality to view most functions, or use the 'class browser' feature
     to view the public-exposed API.
 2.  On the client, many APIs are similar to GTA V's ScriptHookV.NET API.
-3.  Natives exist in `CitizenFX.Core.Native.API`, check the [native reference](native-reference) to find out more.
-
-[native-reference]: https://runtime.fivem.net/doc/natives/
+3.  Natives exist in `CitizenFX.Core.Native.API`, check the [native reference](https://runtime.fivem.net/doc/natives/) to find out more.

--- a/content/docs/scripting-reference/runtimes/csharp/server-functions.md
+++ b/content/docs/scripting-reference/runtimes/csharp/server-functions.md
@@ -8,7 +8,5 @@ There's a few ways to easily tell what functions exist in C# pending manual docu
 
 1.  You can use Visual Studio's IntelliSense functionality to view most functions, or use the 'class browser' feature
     to view the public-exposed API.
-2.  Natives exist in `CitizenFX.Core.Native.API`, check the [native reference](native-reference) to find out more.
+2.  Natives exist in `CitizenFX.Core.Native.API`, check the [native reference](https://runtime.fivem.net/doc/natives/) to find out more.
     (do make sure to filter by server)
-
-[native-reference]: https://runtime.fivem.net/doc/natives/


### PR DESCRIPTION
Originally, when the link to the native reference documentation was pressed, it appended "native-reference" to the end of the uri causing the client to encounter a 404 error. This fixes that issue.