### PR TITLE
fix: "can't evaluate field hash in type int"

### DIFF
--- a/layouts/shortcodes/native.html
+++ b/layouts/shortcodes/native.html
@@ -1,14 +1,30 @@
 {{ $name := .Get 0 }}
 {{ $natives := getJSON "https://runtime.fivem.net/doc/natives.json" }}
+{{ $cfxNatives := getJSON "https://runtime.fivem.net/doc/natives_cfx.json" }}
 {{ $nativeHash := 0 }}
 {{ range $natives }}
-{{ range . }}
-{{ if (eq .name $name) }}
-{{ $nativeHash = .hash }}
+    {{ range . }}
+        {{ if (eq .name $name) }}
+            {{ $nativeHash = .hash }}
+        {{ end }}
+
+        {{ if (in .aliases $name) }}
+            {{ $nativeHash = .hash }}
+        {{ end }}
+    {{ end }}
 {{ end }}
-{{ if (in .aliases $name) }}
-{{ $nativeHash = .hash }}
-{{ end }}
-{{ end }}
+
+{{ if eq $nativeHash 0 }}
+    {{ range $cfxNatives }}
+        {{ range . }}
+            {{ if (eq .name $name) }}
+                {{ $nativeHash = .hash }}
+            {{ end }}
+
+            {{ if (in .aliases $name) }}
+                {{ $nativeHash = .hash }}
+            {{ end }}
+        {{ end }}
+    {{ end }}
 {{ end }}
 https://runtime.fivem.net/doc/natives/?_{{ $nativeHash }}

--- a/layouts/shortcodes/native.html
+++ b/layouts/shortcodes/native.html
@@ -1,14 +1,14 @@
 {{ $name := .Get 0 }}
 {{ $natives := getJSON "https://runtime.fivem.net/doc/natives.json" }}
-{{ $native := 0 }}
+{{ $nativeHash := 0 }}
 {{ range $natives }}
 {{ range . }}
 {{ if (eq .name $name) }}
-{{ $native = . }}
+{{ $nativeHash = .hash }}
 {{ end }}
 {{ if (in .aliases $name) }}
-{{ $native = . }}
+{{ $nativeHash = .hash }}
 {{ end }}
 {{ end }}
 {{ end }}
-https://runtime.fivem.net/doc/natives/#_{{ $native.hash }}
+https://runtime.fivem.net/doc/natives/?_{{ $nativeHash }}

--- a/layouts/shortcodes/native_link.html
+++ b/layouts/shortcodes/native_link.html
@@ -1,14 +1,14 @@
 {{ $name := .Get 0 }}
 {{ $natives := getJSON "https://runtime.fivem.net/doc/natives.json" }}
-{{ $native := 0 }}
+{{ $nativeHash := 0 }}
 {{ range $natives }}
 {{ range . }}
 {{ if (eq .name $name) }}
-{{ $native = . }}
+{{ $nativeHash = .hash }}
 {{ end }}
 {{ if (in .aliases $name) }}
-{{ $native = . }}
+{{ $nativeHash = .hash }}
 {{ end }}
 {{ end }}
 {{ end }}
-{{ (print "[" $name "](https://runtime.fivem.net/doc/natives/#_" $native.hash ")") | markdownify }}
+{{ (print "[" $name "](https://runtime.fivem.net/doc/natives/?_" $nativeHash ")") | markdownify }}

--- a/layouts/shortcodes/native_link.html
+++ b/layouts/shortcodes/native_link.html
@@ -1,14 +1,30 @@
 {{ $name := .Get 0 }}
 {{ $natives := getJSON "https://runtime.fivem.net/doc/natives.json" }}
+{{ $cfxNatives := getJSON "https://runtime.fivem.net/doc/natives_cfx.json" }}
 {{ $nativeHash := 0 }}
 {{ range $natives }}
-{{ range . }}
-{{ if (eq .name $name) }}
-{{ $nativeHash = .hash }}
+    {{ range . }}
+        {{ if (eq .name $name) }}
+            {{ $nativeHash = .hash }}
+        {{ end }}
+        {{ if (in .aliases $name) }}
+            {{ $nativeHash = .hash }}
+        {{ end }}
+    {{ end }}
 {{ end }}
-{{ if (in .aliases $name) }}
-{{ $nativeHash = .hash }}
+
+{{ if eq $nativeHash 0 }}
+    {{ range $cfxNatives }}
+        {{ range . }}
+            {{ if (eq .name $name) }}
+                {{ $nativeHash = .hash }}
+            {{ end }}
+
+            {{ if (in .aliases $name) }}
+                {{ $nativeHash = .hash }}
+            {{ end }}
+        {{ end }}
+    {{ end }}
 {{ end }}
-{{ end }}
-{{ end }}
+
 {{ (print "[" $name "](https://runtime.fivem.net/doc/natives/?_" $nativeHash ")") | markdownify }}

--- a/layouts/shortcodes/native_link.html
+++ b/layouts/shortcodes/native_link.html
@@ -7,6 +7,7 @@
         {{ if (eq .name $name) }}
             {{ $nativeHash = .hash }}
         {{ end }}
+
         {{ if (in .aliases $name) }}
             {{ $nativeHash = .hash }}
         {{ end }}


### PR DESCRIPTION
Fixes building failing when specifying `hash` index directly.

~~Though, because of the removal of the `CFX` namespace at `https://runtime.fivem.net/doc/natives.json`, any `CFX` native passed to `<native_link>` or `<native>`, it will just return `https://runtime.fivem.net/doc/natives/?_0` - as `0` is the default value for `$nativeHash`. Without this, the build will fail.~~

Resolves https://github.com/citizenfx/fivem-docs/issues/120