### PR TITLE
Update Javascript Example

### DIFF
--- a/content/docs/scripting-reference/events/list/playerConnecting.md
+++ b/content/docs/scripting-reference/events/list/playerConnecting.md
@@ -149,10 +149,11 @@ AddEventHandler("playerConnecting", OnPlayerConnecting)
 on('playerConnecting', (name, setKickReason, deferrals) => {
     deferrals.defer()
 
+    const player = global.source;
+
     setTimeout(() => {
         deferrals.update(`Hello ${name}. Your steam ID is being checked.`)
 
-        const player = global.source;
         let steamIdentifier = null;
 
         for (let i = 0; i < GetNumPlayerIdentifiers(player); i++) {


### PR DESCRIPTION
player source is assigned inside setTimeout causing it to be null when called. Moved outside setTimeout in example to fix issue.