### PR TITLE
fix: outdated rmv2

### DIFF
--- a/static/resource_manifest_version2.txt
+++ b/static/resource_manifest_version2.txt
@@ -1,1 +1,1 @@
-bodacious
+cerulean


### PR DESCRIPTION
Displayed resource manifest version 2 is deprecated. This change fixes this issue.