### PR TITLE
Add Lua example for chat:addSuggestions event

### DIFF
--- a/content/docs/resources/chat/events/chat-addSuggestions.md
+++ b/content/docs/resources/chat/events/chat-addSuggestions.md
@@ -23,4 +23,27 @@ array suggestions
 Examples
 --------
 
-TODO
+This example adds a command suggestion for the `/command` and `/othercommand` commands.
+
+##### Lua Example:
+```lua
+-- Note, the command has to start with `/`.
+
+TriggerEvent('chat:addSuggestions', {
+    {
+        name='/command',
+        help='help text',
+        params={
+            { name="paramName1", help="param description 1" },
+            { name="paramName2", help="param description 2" }
+        }
+    },
+    {
+        name='/othercommand',
+        help='other help text',
+        params={
+            { name="otherParamName1", help="other param description 1" },
+            { name="otherParamName2", help="other param description 2" }
+        }
+    },
+})


### PR DESCRIPTION
This event could really use an example as the existing documentation doesn't specify that each suggestion object should be an associative table rather than indexed.