### PR TITLE
Adding More AV Exception Instructions, More Places to Buy GTA, and No More Win 7/8.1

### DIFF
--- a/content/docs/client-manual/disabling-antivirus.md
+++ b/content/docs/client-manual/disabling-antivirus.md
@@ -18,5 +18,5 @@ solution for these issues.
     - [Avast](https://support.avast.com/en-eu/article/Antivirus-scan-exclusions)
     - [AVG](https://support.avg.com/SupportArticleView?urlname=How-to-exclude-file-folder-or-website-from-AVG-scanning)
     - [Bitdefender](https://www.bitdefender.com/consumer/support/answer/13427/)
-    - [Kaspersky](https://usa.kaspersky.com/blog/kaspersky-add-exclusion/11075/#:~:text=How%20to%20add%20an%20application%20to%20exclusions%20in%20Kaspersky%20Internet%20Security)
-    - [McAfee](https://service.mcafee.com/webcenter/portal/oracle/webcenter/page/scopedMD/s55728c97_466d_4ddb_952d_05484ea932c6/Page29.jspx?wc.contextURL=%2Fspaces%2Fcp&articleId=TS102056&_afrLoop=21675571180047&leftWidth=0%25&showFooter=false&showHeader=false&rightWidth=0%25&centerWidth=100%25#!%40%40%3FshowFooter%3Dfalse%26_afrLoop%3D21675571180047%26articleId%3DTS102056%26leftWidth%3D0%2525%26showHeader%3Dfalse%26wc.contextURL%3D%252Fspaces%252Fcp%26rightWidth%3D0%2525%26centerWidth%3D100%2525%26_adf.ctrl-state%3D1a0jwcm100_9)
+    - [Kaspersky](https://usa.kaspersky.com/blog/kaspersky-add-exclusion/11075/)
+    - [McAfee](https://service.mcafee.com/webcenter/portal/oracle/webcenter/page/scopedMD/s55728c97_466d_4ddb_952d_05484ea932c6/Page29.jspx?articleId=TS102056)

--- a/content/docs/client-manual/disabling-antivirus.md
+++ b/content/docs/client-manual/disabling-antivirus.md
@@ -17,3 +17,6 @@ solution for these issues.
 - Add it to your antivirus exclusions. For the common antivirus vendors:
     - [Avast](https://support.avast.com/en-eu/article/Antivirus-scan-exclusions)
     - [AVG](https://support.avg.com/SupportArticleView?urlname=How-to-exclude-file-folder-or-website-from-AVG-scanning)
+    - [Bitdefender](https://www.bitdefender.com/consumer/support/answer/13427/)
+    - [Kaspersky](https://usa.kaspersky.com/blog/kaspersky-add-exclusion/11075/#:~:text=How%20to%20add%20an%20application%20to%20exclusions%20in%20Kaspersky%20Internet%20Security)
+    - [McAfee](https://service.mcafee.com/webcenter/portal/oracle/webcenter/page/scopedMD/s55728c97_466d_4ddb_952d_05484ea932c6/Page29.jspx?wc.contextURL=%2Fspaces%2Fcp&articleId=TS102056&_afrLoop=21675571180047&leftWidth=0%25&showFooter=false&showHeader=false&rightWidth=0%25&centerWidth=100%25#!%40%40%3FshowFooter%3Dfalse%26_afrLoop%3D21675571180047%26articleId%3DTS102056%26leftWidth%3D0%2525%26showHeader%3Dfalse%26wc.contextURL%3D%252Fspaces%252Fcp%26rightWidth%3D0%2525%26centerWidth%3D100%2525%26_adf.ctrl-state%3D1a0jwcm100_9)

--- a/content/docs/client-manual/system-requirements.md
+++ b/content/docs/client-manual/system-requirements.md
@@ -5,7 +5,7 @@ weight: 220
 
 To [run FiveM][installing] your system must meet the [minimum requirements of the original game][gtav-system-specs].
 
-FiveM requires a _fully_ updated version of Windows 7, Windows 8.1 or Windows 10. An outdated operating system may not
+FiveM requires a _fully_ updated version of Windows 10. An outdated operating system may not
 work. It is generally advised to upgrade to Windows 10 when you can as this provides the best experience.
 
 Additional details:

--- a/content/docs/client-manual/system-requirements.md
+++ b/content/docs/client-manual/system-requirements.md
@@ -5,7 +5,7 @@ weight: 220
 
 To [run FiveM][installing] your system must meet the [minimum requirements of the original game][gtav-system-specs].
 
-FiveM requires a _fully_ updated version of Windows 10. An outdated operating system may not
+FiveM requires a _fully_ updated version of Windows 8.1 or Windows 10. An outdated operating system may not
 work. It is generally advised to upgrade to Windows 10 when you can as this provides the best experience.
 
 Additional details:

--- a/content/docs/client-manual/where-to-buy-gtav.md
+++ b/content/docs/client-manual/where-to-buy-gtav.md
@@ -14,3 +14,5 @@ the authors, buy the game.
 - [Epic Games Store](https://www.epicgames.com/store/product/grand-theft-auto-v)
 - [Rockstar Warehouse](https://www.rockstarwarehouse.com/store/tk2rstar/en_IE/pd/productID.332704400)
 - [Amazon](https://www.amazon.com/Grand-Theft-Auto-V-PC/dp/B00KVXB5YQ)
+- [Newegg](https://www.newegg.com/rockstar-games-grand-theft-auto-v-with-gta-online-pc/p/N82E16832137064)
+


### PR DESCRIPTION
Adding more AV vendor links (known that McAfee and Bitdefender block FiveM by default from myself and my friends. Assuming the same with Kaspersky because they take the same aggressive approach as Bitdefender.)
For Kaspersky, that was the best link I could find although it is in a page with other content as well.