### PR TITLE
fix(server setup): example server.cfg refer link

### DIFF
--- a/content/docs/server-manual/setting-up-a-server.md
+++ b/content/docs/server-manual/setting-up-a-server.md
@@ -71,7 +71,7 @@ Make sure you have registered a license key on the [Cfx.re Keymaster](https://ke
   <br>3b. Use any archiving tool (such as WinRAR or 7-Zip).
 4. Clone [cfx-server-data][server-data] in a new folder outside of your server binaries folder, for example, `D:\FXServer\server-data`.
   <br>4b. `git clone https://github.com/citizenfx/cfx-server-data.git server-data`
-5. Make a **server.cfg** file in your `server-data` folder (copy the [example server.cfg](#servercfgexample) file below into that file).
+5. Make a **server.cfg** file in your `server-data` folder (copy the [example server.cfg](#servercfg) file below into that file).
 6. Set the license key in your server.cfg using `sv_licenseKey "licenseKeyGoesHere"`.
 7. Run the server from the `server-data` folder. For example, in a plain Windows command prompt (cmd.exe) window: 
     ```dos
@@ -93,7 +93,7 @@ If you're experiencing any issues, you're more likely to see them fixed if you u
 3. Extract the build to the directory that was previously created, using `cd /home/username/FXServer/server && tar xf fx.tar.xz` (you need to have `xz` installed, on Debian/Ubuntu this is in the `xz-utils` package).
 4. Clone [cfx-server-data][server-data] in a new folder outside of your server binaries folder.
   <br>4b. For example `git clone https://github.com/citizenfx/cfx-server-data.git /home/username/FXServer/server-data`
-5. Make a **server.cfg** file in your `server-data` folder (copy the [example server.cfg](#servercfgexample) file below into that file).
+5. Make a **server.cfg** file in your `server-data` folder (copy the [example server.cfg](#servercfg) file below into that file).
 6. Set the license key in your `server.cfg` using `sv_licenseKey "licenseKeyGoesHere"`.
 7. Run the server from the `server-data` folder.
   <br>7b. `bash /home/username/FXServer/server/run.sh +exec server.cfg`


### PR DESCRIPTION
Changed the link to refer to the server.cfg example in server manual / setting up a server