### PR TITLE
tweak(client-manual): add note about resmon use

### DIFF
--- a/content/docs/client-manual/console-commands.md
+++ b/content/docs/client-manual/console-commands.md
@@ -170,6 +170,8 @@ Internal dev tool. Not of use to a regular user, and can not be toggled at runti
 The resmon command will open the resource monitor. The resource monitor monitors the CPU usage and memory usage for each
 resource and shows this in a nice overview. Comes in handy when you encounter performance issues during gameplay.
 
+Note: to use `resmon` you have to either be running a Canary build or add `+set moo 31337` to your FiveM shortcut.
+
 Usage: `resmon <true|false>`
 
 ### save_gta_cache


### PR DESCRIPTION
Adds a note about using `resmon` now that it needs Canary or `+set moo 31337`. Chose this location since it is the first result of "fivem resmon" on Google, but it might not be the best placement in the docs. I'm happy to relocate it if anyone has any better suggestions!

Either way: this should hopefully add some visibility on how to use `resmon` so people don't use Canary for no reason other than accessing `resmon`.

For reference, Google:
<img width="725" alt="CleanShot 2021-07-05 at 21 41 22@2x" src="https://user-images.githubusercontent.com/85080314/124512881-c6547e80-ddd9-11eb-84d8-72c3666f16e4.png">