### PR TITLE
Simplify readability with all-in-one RegisterNetEvent

### DIFF
--- a/content/docs/scripting-manual/working-with-events/listening-for-events.md
+++ b/content/docs/scripting-manual/working-with-events/listening-for-events.md
@@ -59,10 +59,7 @@ To register an event as a network event, place this in your client/server script
 
 **Lua**
 ```lua
-RegisterNetEvent("eventName")
-
--- The event handler function follows after registering the event first.
-AddEventHandler("eventName", function(eventParam1, eventParam2)
+RegisterNetEvent("eventName", function(eventParam1, eventParam2)
     -- Code here will be executed once the event is triggered.
 end)
 ```

--- a/content/docs/scripting-reference/runtimes/lua/functions/TriggerClientEvent.md
+++ b/content/docs/scripting-reference/runtimes/lua/functions/TriggerClientEvent.md
@@ -22,13 +22,27 @@ Examples
 --------
 
 -- CLIENT
+
+Lua's traditional way to register a net event and add an event handler:
 ```lua
-RegisterNetEvent('eventName', function(text)
-  print(('I just received %s from the server'):format(text)) -- I just received Hello world! from the server
+RegisterNetEvent("eventName")
+-- The event handler function follows after registering the event first.
+AddEventHandler("eventName", function(eventParam1, eventParam2)
+    -- Code here will be executed once the event is triggered.
 end)
 ```
+
+Lua's new simplified way:
+```lua
+RegisterNetEvent("eventName", function(eventParam1, eventParam2)
+    -- Code here will be executed once the event is triggered.
+end)
+```
+
 -- SERVER
 ```lua
 TriggerClientEvent('eventName', playerId, 'Hello world!')
 ```
+
+[AddEventHandler]: /docs/scripting-reference/runtimes/lua/functions/AddEventHandler/
 [RegisterNetEvent]: /docs/scripting-reference/runtimes/lua/functions/RegisterNetEvent/

--- a/content/docs/scripting-reference/runtimes/lua/functions/TriggerClientEvent.md
+++ b/content/docs/scripting-reference/runtimes/lua/functions/TriggerClientEvent.md
@@ -32,7 +32,7 @@ AddEventHandler("eventName", function(eventParam1, eventParam2)
 end)
 ```
 
-Lua's new simplified way:
+Lua's simplified way:
 ```lua
 RegisterNetEvent("eventName", function(eventParam1, eventParam2)
     -- Code here will be executed once the event is triggered.

--- a/content/docs/scripting-reference/runtimes/lua/functions/TriggerClientEvent.md
+++ b/content/docs/scripting-reference/runtimes/lua/functions/TriggerClientEvent.md
@@ -22,10 +22,8 @@ Examples
 --------
 
 -- CLIENT
-
-Don't forget to [RegisterNetEvent][]!
 ```lua
-AddEventHandler('eventName', function(text)
+RegisterNetEvent('eventName', function(text)
   print(('I just received %s from the server'):format(text)) -- I just received Hello world! from the server
 end)
 ```


### PR DESCRIPTION
Hi there,

with the addition of the compact RegisterNetEvent that also do AddEventHandler in the background,
do we want to suggest new dev to use it in place of AddEventHandler + RegisterNetEvent ?

That would simplify readability of future resources, but also hide the little "complexity" hided behind this.