### PR TITLE
Update rockstar store link to buy GTA V

### DIFF
--- a/content/docs/client-manual/where-to-buy-gtav.md
+++ b/content/docs/client-manual/where-to-buy-gtav.md
@@ -12,7 +12,7 @@ the authors, buy the game.
 
 - [Steam](https://store.steampowered.com/app/271590/Grand_Theft_Auto_V/)
 - [Epic Games Store](https://www.epicgames.com/store/product/grand-theft-auto-v)
-- [Rockstar Warehouse](https://www.rockstarwarehouse.com/store/tk2rstar/en_IE/pd/productID.332704400)
+- [Rockstar Warehouse](https://store.rockstargames.com/en/game/buy-gta-v-premium-edition)
 - [Amazon](https://www.amazon.com/Grand-Theft-Auto-V-PC/dp/B00KVXB5YQ)
 - [Newegg](https://www.newegg.com/rockstar-games-grand-theft-auto-v-with-gta-online-pc/p/N82E16832137064)
 


### PR DESCRIPTION
The old link didn't work, it seems premium edition is the only version of the game you can buy.