### PR TITLE
Update discord link and server support channel.

### DIFF
--- a/content/docs/server-manual/setting-up-a-server.md
+++ b/content/docs/server-manual/setting-up-a-server.md
@@ -7,7 +7,7 @@ description: >
 
 FXServer is the name of the Cfx.re platform server. This page shows you how to run it.
 
-Having trouble running your server? Visit [server issues][server-issues], use the Discord [#fxserver-support][fxserver-support] channel or create a topic in the [Server Discussion][fxserver-support-category] sub-category on the forum.
+Having trouble running your server? Visit [server issues][server-issues], use the Discord [#server-talk][server-talk] channel or create a topic in the [Server Discussion][fxserver-support-category] sub-category on the forum.
 
 ## Before you begin
 Make sure you have registered a license key on the [Cfx.re Keymaster](https://keymaster.fivem.net/) service. You need to have the IP match the *public* IP on which you're going to *first* use the key. Afterwards, the key can be used on any IP, but only on one server at a time.
@@ -131,5 +131,5 @@ What's next?
 [server-commands]: /docs/server-manual/server-commands
 [scripting-introduction]: /docs/scripting-manual/introduction
 
-[fxserver-support]: https://discord.gg/UwvVgsJ
+[server-talk]: https://discord.gg/fivem
 [fxserver-support-category]: https://forum.cfx.re/c/server-development/server-discussion


### PR DESCRIPTION
Uses the FiveM Discord vanity URL, the old one expired. 
Also updated the channel name to #server-talk