### PR TITLE
Add nuget package reference for C# Client

### DIFF
--- a/content/docs/scripting-manual/runtimes/csharp.md
+++ b/content/docs/scripting-manual/runtimes/csharp.md
@@ -44,6 +44,8 @@ Getting the client dependency is very easy. Simply go to your local installation
 ```ini
 FiveM Application Data\citizen\clr2\lib\mono\4.5\CitizenFX.Core.dll
 ```
+<br><br>{{% alert theme="info" %}}If you are working on machine where FiveM is not installed, you can obtain the dependency via NuGet Package: https://www.nuget.org/packages/CitizenFX.Core/ {{% /alert %}}
+  
 Now, go back into Visual Studio and go to your project in the Solution Explorer on the right. Right click on your (client) project, and click "Add > Reference".
 The following window should appear: ![screenshot-3](/csharp-tut-3.png)
 In that window, click on "Browse..." and go to your project folder. Find the CitizenFX.Core.dll file, select it, and press Add. You should now see that the DLL has been added to the "Browse > Recent" list. Make sure that the checkbox in front of the reference **is** checked, and click "OK" in the bottom right.

--- a/content/docs/scripting-manual/runtimes/csharp.md
+++ b/content/docs/scripting-manual/runtimes/csharp.md
@@ -46,8 +46,9 @@ Getting the client dependency is very easy. Simply go to your local installation
 ```ini
 FiveM Application Data\citizen\clr2\lib\mono\4.5\CitizenFX.Core.dll
 ```
-<br><br>{{% alert theme="info" %}}If you are working on machine where FiveM is not installed, you can obtain the dependency via NuGet Package: https://www.nuget.org/packages/CitizenFX.Core/ {{% /alert %}}
-  
+
+<br>{{% alert theme="info" %}}If you are working on machine where FiveM is not installed, you can obtain the dependency via NuGet Package: https://www.nuget.org/packages/CitizenFX.Core/ {{% /alert %}}<br>
+
 Now, go back into Visual Studio and go to your project in the Solution Explorer on the right. Right click on your (client) project, and click "Add > Reference".
 The following window should appear: ![screenshot-3](/csharp-tut-3.png)
 In that window, click on "Browse..." and go to your project folder. Find the CitizenFX.Core.dll file, select it, and press Add. You should now see that the DLL has been added to the "Browse > Recent" list. Make sure that the checkbox in front of the reference **is** checked, and click "OK" in the bottom right.

--- a/content/docs/scripting-manual/runtimes/csharp.md
+++ b/content/docs/scripting-manual/runtimes/csharp.md
@@ -20,7 +20,9 @@ Before you can create your first C# resource, you'll need to install [Visual Stu
   - If this is going to be a client script, name it something like `MyResourceNameClient`.
   - If it's going to be a server script, name it something like `MyResourceNameServer`.
   - If it's going to be a script for both the server and the client, we'll consider this a Client script for now because we will create the Server project for this resource later.
-<br><br>{{% alert theme="info" %}}You might want to change the "Solution name:" to something simpler. Instead of **MyResourceName[Server/Client]** you probably want to change it to just **MyResourceName**.<br>However, this is completely up to you.{{% /alert %}}
+
+<br>{{% alert theme="info" %}}You might want to change the "Solution name:" to something simpler. Instead of **MyResourceName[Server/Client]** you probably want to change it to just **MyResourceName**.<br>However, this is completely up to you.{{% /alert %}}<br>
+
 5. After choosing a proper name, click "Browse..." to choose a folder where you want to save this project, or click "OK" if you want to save it in the default location.
 ### Additional project
 **You can skip these steps if you only created a server or client side project, however continue reading if you need both a client and a server sided project.**


### PR DESCRIPTION
Add a link to [official CitizenFX NuGet Package](https://www.nuget.org/packages/CitizenFX.Core.Client/) for the **CitizenFX.Core** client script dependency, useful for those who develop on separate machine where FiveM is not installed