### PR TITLE
Fix for broken installation guide list

### DIFF
--- a/content/docs/server-manual/setting-up-a-server.md
+++ b/content/docs/server-manual/setting-up-a-server.md
@@ -68,9 +68,9 @@ Make sure you have registered a license key on the [Cfx.re Keymaster](https://ke
 1. Create a new directory (for example `D:\FXServer\server`), this will be used for the server binaries.
 2. Download the current recommended `master` branch build for Windows from the [artifacts server][windows-artifacts].
 3. Extract the build into the directory previously created.
-  <br>3b. Use any archiving tool (such as WinRAR or 7-Zip).
+3b. Use any archiving tool (such as WinRAR or 7-Zip).
 4. Clone [cfx-server-data][server-data] in a new folder outside of your server binaries folder, for example, `D:\FXServer\server-data`.
-  <br>4b. `git clone https://github.com/citizenfx/cfx-server-data.git server-data`
+4b. `git clone https://github.com/citizenfx/cfx-server-data.git server-data`
 5. Make a **server.cfg** file in your `server-data` folder (copy the [example server.cfg](#servercfg) file below into that file).
 6. Set the license key in your server.cfg using `sv_licenseKey "licenseKeyGoesHere"`.
 7. Run the server from the `server-data` folder. For example, in a plain Windows command prompt (cmd.exe) window: 
@@ -92,11 +92,11 @@ If you're experiencing any issues, you're more likely to see them fixed if you u
 2. Download the current recommended `master` branch build for Linux from the [artifacts server][linux-artifacts](copy the URL for the latest server version and use `wget <url>` to download it).
 3. Extract the build to the directory that was previously created, using `cd /home/username/FXServer/server && tar xf fx.tar.xz` (you need to have `xz` installed, on Debian/Ubuntu this is in the `xz-utils` package).
 4. Clone [cfx-server-data][server-data] in a new folder outside of your server binaries folder.
-  <br>4b. For example `git clone https://github.com/citizenfx/cfx-server-data.git /home/username/FXServer/server-data`
+4b. For example `git clone https://github.com/citizenfx/cfx-server-data.git /home/username/FXServer/server-data`
 5. Make a **server.cfg** file in your `server-data` folder (copy the [example server.cfg](#servercfg) file below into that file).
 6. Set the license key in your `server.cfg` using `sv_licenseKey "licenseKeyGoesHere"`.
 7. Run the server from the `server-data` folder.
-  <br>7b. `bash /home/username/FXServer/server/run.sh +exec server.cfg`
+7b. `bash /home/username/FXServer/server/run.sh +exec server.cfg`
 
 ### Common issues
 


### PR DESCRIPTION
Fix for broken installation guide list on https://docs.fivem.net/docs/server-manual/setting-up-a-server/