### PR TITLE
Fix default variables for sv_authMinTrust and sv_authMaxVariance

### DIFF
--- a/content/docs/server-manual/server-commands.md
+++ b/content/docs/server-manual/server-commands.md
@@ -231,13 +231,13 @@ sv_master1 ""
 
 **Variance** is how likely the user's id will change for a given provider (i.e. 'steam', 'ip', or 'license').
 
-A console variable as an integer from 1-5 (default 1); from least to most likely to change.
+A console variable as an integer from 1-5 (default 5); from least to most likely to change.
 
 ### `sv_authMinTrust [newValue]`
 
 **Trust** is how _unlikely_ it is for the user's identity to be spoofed by a malicious client.
 
-A console variable as an integer from 1-5 (default 5); from least to most trustworthy (5 being a method such as external three-way authentication).
+A console variable as an integer from 1-5 (default 1); from least to most trustworthy (5 being a method such as external three-way authentication).
 
 ### `load_server_icon [fileName.png]`
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/55849405/165405696-ee4ff04b-b9d5-4162-83d4-2b7c7e4b0104.png)

According to the above, these are documented, on the docs, the wrong way around.