### PR TITLE
Add 2612 (mpg9ec) to the list of FiveM builds.

### DIFF
--- a/content/docs/server-manual/server-commands.md
+++ b/content/docs/server-manual/server-commands.md
@@ -167,6 +167,7 @@ Every build includes all content and changes from the builds before.
 | 2189   | h4, heist4, mpheist4                 | Cayo Perico Heist           |
 | 2372   | tuner, mptuner                       | Los Santos Tuners           |
 | 2545   | security, mpsecurity                 | The Contract                |
+| 2612   | mpg9ec                               | -                           |
 
 **RedM builds**
 


### PR DESCRIPTION
Couldn't seem to find a marketing name for this since it just seems to be a patch tailored to improve performance on Gen 9 consoles including a motion blur slider, as well as fixing other game play related issues.