### PR TITLE
Create documentation contribution FAQ

### DIFF
--- a/content/docs/support/documentation-faq.md
+++ b/content/docs/support/documentation-faq.md
@@ -1,0 +1,35 @@
+---
+title: Requesting Documentation
+weight: 850
+---
+
+Missing Documentation
+--------------------------------
+Do you feel as if there's missing documentation? As of now there's a few sections (detailed down below) to request documentation to be written.
+
+Where are these sections?
+--------------------------------
+[General documentation](https://docs.fivem.net/) has its own [Github issues](https://github.com/citizenfx/fivem-docs/issues) section and [natives](https://docs.fivem.net/natives/) have their own section located [here](https://github.com/citizenfx/natives/issues) as well.
+
+How do I open an issue in any of these sections?
+--------------------------------
+You can open a new issue by clicking on a green button that reads *"New Issue"*, located on the top right once you access any of the pages detailed up above (Where are these sections?).
+
+If you don't have a Github account, Github will prompt you to [sign up](https://github.com/signup) for one.
+
+What should the "issue" I'm creating consist of?
+--------------------------------
+For starters, your title should be descriptive, for example, if it's for missing docs, it should go something along the lines of *"I'm requesting anyone to please document 'x' missing feature."*.
+
+If it's an issue within the documentation, you should indicate in the title that this is an issue within the documentation itself and for the description, you should indicate _what exactly it is that is wrong within the documentation, preferably with a url/link pointing to it._ A good example of such would be [this](https://github.com/citizenfx/fivem-docs/issues/332), it tells the reader what the issue is, and points them to it.
+
+What if I just want to help with documentation?
+--------------------------------
+There are several ways you can do this, the most common one is by creating a fork to the repositories (listed up [above](#where-are-these-sections)) and then creating pull requests from them. These will generally be reviewed by the community and elements, once approved they will be added to the documentation.
+
+If you're not sure on how to fork a repository or create a pull request, you can check these out:
+
+- [Fork a repo](https://docs.github.com/es/get-started/quickstart/fork-a-repo)
+- [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
+
+The other way you can help is by accessing PRs and correcting things that may be wrong or simply by contributing any findings you may have (upon research). Anyone with a Github account can contribute in any way.


### PR DESCRIPTION
I created this section to try and address a request where a user correctly claimed that there's missing documentation. The main goal behind this FAQ is emphasizing on the importance of the Github issues  section for both natives and docs.

It's difficult to know what's higher in priority to document when there's users with different needs, emphasizing on creating issues for documentation and natives will hopefully help with this, especially if multiple users come up with a common goal.