### PR TITLE
update(markers): Add description for Jetpack Symbol and Cube.

### DIFF
--- a/content/docs/game-references/markers.md
+++ b/content/docs/game-references/markers.md
@@ -78,7 +78,7 @@ Markers
 <div class="marker"><span><img src="/markers/38.png" alt="38"><br><strong>38</strong><br>MarkerTypeBikeSymbol</span></div>
 <div class="marker"><span><img src="/markers/39.png" alt="39"><br><strong>39</strong><br>MarkerTypeTruckSymbol</span></div>
 <div class="marker"><span><img src="/markers/40.png" alt="40"><br><strong>40</strong><br>MarkerTypeParachuteSymbol</span></div>
-<div class="marker"><span><img src="/markers/41.png" alt="41"><br><strong>41</strong><br>?</span></div>
+<div class="marker"><span><img src="/markers/41.png" alt="41"><br><strong>41</strong><br>MarkerTypeJetpackSymbol</span></div>
 <div class="marker"><span><img src="/markers/42.png" alt="42"><br><strong>42</strong><br>MarkerTypeSawbladeSymbol</span></div>
-<div class="marker"><span><img src="/markers/43.png" alt="43"><br><strong>43</strong><br>?</span></div>
+<div class="marker"><span><img src="/markers/43.png" alt="43"><br><strong>43</strong><br>MarkerTypeCube</span></div>
 </div>


### PR DESCRIPTION
Update descriptions to add wording for Jetpack and Cube.

Cube I'd open for discussion as its just an oblong but that just adds more confusion.

Note: C# Nuget CitizenFX.Core.MarkerType has Sawblade symbol as 41, as its missing Jetpack and Cube markers.
https://github.com/citizenfx/fivem/blob/cbe56f78f86bebb68d7960a38c3cdc31c7d76790/code/client/clrcore/External/World.cs#L195

Could be worth waiting till that file is updated?