### PR TITLE
Clarified instruction to open a command-line interface

### DIFF
--- a/content/docs/scripting-manual/runtimes/csharp.md
+++ b/content/docs/scripting-manual/runtimes/csharp.md
@@ -10,7 +10,7 @@ Before you can create your first C# resource, you'll need to install [Visual Stu
 
 
 ## Creating your project
-1. Open a command window by pressing `Win + R`, you should have a console like the one below:
+1. Open a command window by pressing `Win + R` and type in `cmd`. Then you should have a console like the one below:
 
 ![screenshot-1](/csharp-tut-1.png)
 

--- a/content/docs/scripting-manual/runtimes/csharp.md
+++ b/content/docs/scripting-manual/runtimes/csharp.md
@@ -10,7 +10,7 @@ Before you can create your first C# resource, you'll need to install [Visual Stu
 
 
 ## Creating your project
-1. Open a command window by pressing `Win + R` and type in `cmd`. Then you should have a console like the one below:
+1. Open a command window by pressing `Win + R`, type in `cmd` and then press `Enter`. Now you should have a console like the one below:
 
 ![screenshot-1](/csharp-tut-1.png)
 


### PR DESCRIPTION
This PR clarifies the instruction on how to open a command-line interface by the shortcut `WIN + R`.
I updated it, as you have to type in `cmd` top open an actual command-line interface.