### PR TITLE
Replace the list of natives with a link to the Native Reference.

### DIFF
--- a/content/docs/scripting-reference/client-functions/_index.md
+++ b/content/docs/scripting-reference/client-functions/_index.md
@@ -5,21 +5,17 @@ weight: 502
 
 Here is a list of some of the functions that you can use specifically in **client** side scripts.
 
+Native functions
+----------------
+Native functions are provided by both the game and the Citizen framework (under the [CFX](/natives/?n_CFX) heading). Refer to the [FiveM Native Reference](/docs/natives), where you can see syntax per language, a description, and examples for each native.
+
+These natives are usable in **all** runtimes.
+
 Runtime specific functions
 --------------------------
 Some functions are exclusive to the scripting runtime you're using, and are **not** documented
-in the [FiveM Native Reference List](https://runtime.fivem.net/doc/reference.html). Refer to their docs for more detail.
+in the [FiveM Native Reference List](/docs/natives). Refer to their docs for more detail.
 
 - [Client-side functions in Lua](/docs/scripting-reference/runtimes/lua/client-functions)
 - [Client-side functions in JavaScript](/docs/scripting-reference/runtimes/javascript/client-functions)
 - [Client-side functions in C#](/docs/scripting-reference/runtimes/csharp/client-functions)
-
-Native functions
-----------------
-These are native functions provided by both the Citizen framework (under the [CFX](#cfx) heading), as well as by the
-game. Clicking each link will lead to the FiveM native reference, where you can see syntax per language, a description,
-and examples for using the native.
-
-These natives are usable in **all** runtimes.
-
-{{% native_list "client" %}}

--- a/content/docs/scripting-reference/runtimes/javascript/client-functions.md
+++ b/content/docs/scripting-reference/runtimes/javascript/client-functions.md
@@ -12,6 +12,4 @@ weight: 511
 - [clearTick](/docs/scripting-reference/runtimes/javascript/functions/clearTick)
 
 ## Native functions
-These links will redirect to the native reference page for each function.
-
-{{% native_list "client" "lua" %}}
+Refer to the [FiveM Native Reference](/docs/natives) for game functions.

--- a/content/docs/scripting-reference/runtimes/javascript/server-functions.md
+++ b/content/docs/scripting-reference/runtimes/javascript/server-functions.md
@@ -13,6 +13,4 @@ weight: 512
 - [clearTick](/docs/scripting-reference/runtimes/javascript/functions/clearTick)
 
 ## Native functions
-These links will redirect to the native reference page for each function.
-
-{{% native_list "server" "lua" %}}
+Refer to the [FiveM Native Reference](/docs/natives) for game functions.

--- a/content/docs/scripting-reference/runtimes/lua/client-functions.md
+++ b/content/docs/scripting-reference/runtimes/lua/client-functions.md
@@ -23,6 +23,4 @@ weight: 514
 - [vector4](/docs/scripting-reference/runtimes/lua/functions/vector4)
 
 ## Native functions
-These links will redirect to the native reference page for each function.
-
-{{% native_list "client" "lua" %}}
+Refer to the [FiveM Native Reference](/docs/natives) for game functions.

--- a/content/docs/scripting-reference/runtimes/lua/server-functions.md
+++ b/content/docs/scripting-reference/runtimes/lua/server-functions.md
@@ -19,6 +19,4 @@ weight: 515
 - [TriggerEvent](/docs/scripting-reference/runtimes/lua/functions/TriggerEvent)
 
 ## Native functions
-These links will redirect to the native reference page for each function.
-
-{{% native_list "server" "lua" %}}
+Refer to the [FiveM Native Reference](/docs/natives) for game functions.

--- a/content/docs/scripting-reference/server-functions/_index.md
+++ b/content/docs/scripting-reference/server-functions/_index.md
@@ -5,6 +5,12 @@ weight: 504
 
 Here is a list of some of the functions that you can use specifically in **server** side scripts.
 
+Native functions
+----------------
+Server-side native functions are provided by the Citizen framework. Refer to the [FiveM Native Reference](/docs/natives), where you can see syntax per language, a description, and examples for each native.
+
+These natives are usable in **all** runtimes.
+
 Runtime specific functions
 --------------------------
 Some functions are exclusive to the scripting runtime you're using, and are **not** documented
@@ -13,12 +19,3 @@ in the [FiveM Native Reference List](https://runtime.fivem.net/doc/reference.htm
 - [Server-side functions in Lua](/docs/scripting-reference/runtimes/lua/server-functions)
 - [Server-side functions in JavaScript](/docs/scripting-reference/runtimes/javascript/server-functions)
 - [Server-side functions in C#](/docs/scripting-reference/runtimes/csharp/server-functions)
-
-Native functions
-----------------
-These are native functions provided by the Citizen framework. Clicking each link will lead to the FiveM native
-reference, where you can see syntax per language, a description, and examples for using the native.
-
-These natives are usable in **all** runtimes.
-
-{{% native_list "server" %}}


### PR DESCRIPTION
Reducing unnecessary redundancy and addressing performance concerns.