### PR TITLE
tweak(server-manual/zap): change Patreon wording

### DIFF
--- a/content/docs/server-manual/setting-up-a-server-zap.md
+++ b/content/docs/server-manual/setting-up-a-server-zap.md
@@ -12,8 +12,8 @@ description: >
 3. A dialog will show where you can `Choose your product`. We will be using a Cloud Gameserver, so click `Gameserver` followed by `Cloud Gameserver`.
 4. A new page will show, scroll down until you find `Search for games`, enter `FiveM`. We will be using `FIVE: FiveM Mod (Windows)`, so make sure to click on it. Optionally, you can [click this link][zap-rent-a-windows-server].
 5. Pick the server location, we're going to be using a server located in Germany for this example.
-6. Scroll down and customize your server to your liking, remember that to use more than 48 slots, you will need OneSync, which can be obtained from Patreon, starting from [FiveM Element Club Argentum 💿][patreon-join]. 
-    - If you plan to use a OneSync premium plan, you should register your server with the same email address as the one used for your patreon membership, so it's then automatically configured by ZAP-Hosting.
+6. Scroll down and customize your server to your liking, remember that to use more than 48 slots, you will need a Cfx.re Patreon subscription, starting from [FiveM Element Club Argentum 💿][patreon-join]. 
+    - If you plan to get the Patreon subscription, you should register your server with the same email address as the one used for your patreon membership, so it's then automatically configured by ZAP-Hosting.
 7. Choose your preferred payment method and agree to the terms, remember to be logged in as detailed on `Step 1`.
 8. Once you confirm the order, the server will be up. Once the server is up an `Initial installation will be required` dialog should be shown, click on `Install`.
 9. You should now be able to access your game-panel where an IP address will be shown, copy it to access your game-server.

--- a/content/docs/server-manual/setting-up-a-server-zap.md
+++ b/content/docs/server-manual/setting-up-a-server-zap.md
@@ -12,8 +12,9 @@ description: >
 3. A dialog will show where you can `Choose your product`. We will be using a Cloud Gameserver, so click `Gameserver` followed by `Cloud Gameserver`.
 4. A new page will show, scroll down until you find `Search for games`, enter `FiveM`. We will be using `FIVE: FiveM Mod (Windows)`, so make sure to click on it. Optionally, you can [click this link][zap-rent-a-windows-server].
 5. Pick the server location, we're going to be using a server located in Germany for this example.
-6. Scroll down and customize your server to your liking, remember that to use more than 48 slots, you will need a Cfx.re Patreon subscription, starting from [FiveM Element Club Argentum 💿][patreon-join]. 
-    - If you plan to get the Patreon subscription, you should register your server with the same email address as the one used for your patreon membership, so it's then automatically configured by ZAP-Hosting.
+6. Scroll down and customize your server to your liking, remember that to use more than 48 slots, you will need [FiveM Element Club Argentum 💿][patreon-join] or above, which can be obtained from Patreon.
+    - If you plan to get a subscription through Patreon, you should register your server with the same email address as the one used for your Cfx.re account, so that your plan is automatically detected and configured.
+    - When hosting a server with ZAP-Hosting, you'll need to add the license key associated to your Cfx.re account to your server instance. You may find the guide [here][zap-hosting-license-key-guide].
 7. Choose your preferred payment method and agree to the terms, remember to be logged in as detailed on `Step 1`.
 8. Once you confirm the order, the server will be up. Once the server is up an `Initial installation will be required` dialog should be shown, click on `Install`.
 9. You should now be able to access your game-panel where an IP address will be shown, copy it to access your game-server.
@@ -26,4 +27,5 @@ Guide adapted from [here][zap-hosting-youtube-video].
 [zap-rent-a-server]: https://zap-hosting.com/en/gameserver-hosting/
 [zap-rent-a-windows-server]: https://zap-hosting.com/en/shop/product/cloud-gameserver/fivem-mod-windows/
 [zap-hosting-youtube-video]: https://www.youtube.com/watch?v=wJWICcBfA0I
+[zap-hosting-license-key-guide]: https://zap-hosting.com/guides/docs/fivem-licensekey/
 [patreon-join]: https://www.patreon.com/join/fivem


### PR DESCRIPTION
Current wording makes it seem like OneSync is a paid, Patreon, feature. Which has not been the case since December 2020. The new wording focuses it on the slot count instead, which *is* a Patreon feature