### PR TITLE
Added missing parameter and example to leftVehicle.md

### DIFF
--- a/content/docs/resources/baseevents/events/leftVehicle.md
+++ b/content/docs/resources/baseevents/events/leftVehicle.md
@@ -12,14 +12,28 @@ Parameters
 ----------
 
 ```
-vehicle currentVehicle, int currentSeat, string vehicleDisplayName
+vehicle currentVehicle, int currentSeat, string vehicleDisplayName, int vehicleNetId
 ```
 
 - **currentVehicle**: The handle of the vehicle the player just left.
 - **currentSeat**: The seat number (-1 is drivers seat, 0 = passenger right front, etc.) in which the player was previously sitting.
 - **vehicleDisplayName**: A string containing the display name of the vehicle the player just left.
+- **vehicleNetId**: The netId of the vehicle. Can be used with NetToVeh() to get the vehicle client side.
 
 Examples
 --------
 
 TODO
+Server.lua 
+```
+RegisterNetEvent("baseevents:leftVehicle", function(currentVehicle, currentSeat, vehicleDisplayName, netId)
+    TriggerClientEvent("example:leftVeh", -1, netId)
+end)
+```
+Client.lua
+```
+RegisterNetEvent("example:leftVeh", function(NetId)
+    local veh = NetToVeh(NetId)
+    print("Somebody left the vehicle: " .. veh )
+end)
+```

--- a/content/docs/resources/baseevents/events/leftVehicle.md
+++ b/content/docs/resources/baseevents/events/leftVehicle.md
@@ -19,7 +19,7 @@ vehicle currentVehicle, int currentSeat, string vehicleDisplayName, int vehicleN
 - **currentVehicle**: The handle of the vehicle the player just left.
 - **currentSeat**: The seat number (-1 is drivers seat, 0 = passenger right front, etc.) in which the player was previously sitting.
 - **vehicleDisplayName**: A string containing the display name of the vehicle the player just left.
-- **vehicleNetId**: The netId of the vehicle. Can be used with NetToVeh() to get the vehicle client side.
+- **vehicleNetId**: The Network ID of the vehicle. Can be used with NetToVeh() to get the vehicle client side.
 
 Examples
 --------

--- a/content/docs/resources/baseevents/events/leftVehicle.md
+++ b/content/docs/resources/baseevents/events/leftVehicle.md
@@ -19,7 +19,7 @@ vehicle currentVehicle, int currentSeat, string vehicleDisplayName, int vehicleN
 - **currentVehicle**: The handle of the vehicle the player just left.
 - **currentSeat**: The seat number (-1 is drivers seat, 0 = passenger right front, etc.) in which the player was previously sitting.
 - **vehicleDisplayName**: A string containing the display name of the vehicle the player just left.
-- **vehicleNetId**: The Network ID of the vehicle. Can be used with NetToVeh() to get the vehicle client side.
+- **vehicleNetId**: The Network ID of the vehicle. Can be used with `NetToVeh()` to get the vehicle client side.
 
 Examples
 --------

--- a/content/docs/resources/baseevents/events/leftVehicle.md
+++ b/content/docs/resources/baseevents/events/leftVehicle.md
@@ -22,8 +22,6 @@ vehicle currentVehicle, int currentSeat, string vehicleDisplayName, int vehicleN
 
 Examples
 --------
-
-TODO
 Server.lua 
 ```
 RegisterNetEvent("baseevents:leftVehicle", function(currentVehicle, currentSeat, vehicleDisplayName, netId)

--- a/content/docs/resources/baseevents/events/leftVehicle.md
+++ b/content/docs/resources/baseevents/events/leftVehicle.md
@@ -4,6 +4,7 @@ title: leftVehicle
 
 Name
 ----------
+
 ```
 baseevents:leftVehicle
 ```
@@ -22,12 +23,14 @@ vehicle currentVehicle, int currentSeat, string vehicleDisplayName, int vehicleN
 
 Examples
 --------
+
 Server.lua 
 ```
 RegisterNetEvent("baseevents:leftVehicle", function(currentVehicle, currentSeat, vehicleDisplayName, netId)
     TriggerClientEvent("example:leftVeh", -1, netId)
 end)
 ```
+
 Client.lua
 ```
 RegisterNetEvent("example:leftVeh", function(NetId)

--- a/content/docs/resources/baseevents/events/leftVehicle.md
+++ b/content/docs/resources/baseevents/events/leftVehicle.md
@@ -26,8 +26,8 @@ Examples
 
 Server.lua 
 ```
-RegisterNetEvent("baseevents:leftVehicle", function(currentVehicle, currentSeat, vehicleDisplayName, netId)
-    TriggerClientEvent("example:leftVeh", -1, netId)
+RegisterNetEvent("baseevents:leftVehicle", function(currentVehicle, currentSeat, vehicleDisplayName, vehicleNetId)
+    TriggerClientEvent("example:leftVeh", -1, vehicleNetId)
 end)
 ```
 
@@ -35,6 +35,6 @@ Client.lua
 ```
 RegisterNetEvent("example:leftVeh", function(NetId)
     local veh = NetToVeh(NetId)
-    print("Somebody left the vehicle: " .. veh )
+    print("Somebody left the vehicle: " .. veh)
 end)
 ```


### PR DESCRIPTION
As you can see in line 41 in \resources\[cfx-default]\[system]\baseevents\vehiclechecker.lua, the event passes a 4th, undocumented parameter. 

Code in question:
```
TriggerServerEvent('baseevents:enteredVehicle', currentVehicle, currentSeat, GetDisplayNameFromVehicleModel(GetEntityModel(currentVehicle)), netId)
```