### PR TITLE
Reference AddStateBagChangeHandler to docs.

### DIFF
--- a/content/docs/scripting-manual/networking/state-bags.md
+++ b/content/docs/scripting-manual/networking/state-bags.md
@@ -78,6 +78,13 @@ Entity(vehicle).state:set('clone', 600, false)
 Entity(enemy).state:set('taskAck', 'guard', true)
 ```
 
+#### Change handlers
+State bag change handlers are essentially method handlers utilized to track changes to a state bag.
+
+Once a change is detected on either side i.e. server, its counterpart implementation (the one on the client) is called with the updated data.
+
+An example implementation method can be found in the following native documentation [AddStateBagChangeHandler](/natives/?_0x5BA35AAF).
+
 ## Policy
 
 Currently, the only policy limitation implemented is to filter _player_ state to be able to be written by the player and the server, _entity_ state to be written by the owning player and the server, and _global_ state to be able to be written by the server.


### PR DESCRIPTION
Adds a `AddStateBagChangeHandler` reference to state bags and also adds a link to an example showing how it's implemented, since the native reference provides examples for Lua and Javascript.