### PR TITLE
Add License Types & Providers

### DIFF
--- a/content/docs/scripting-reference/runtimes/lua/functions/GetPlayerIdentifiers.md
+++ b/content/docs/scripting-reference/runtimes/lua/functions/GetPlayerIdentifiers.md
@@ -28,7 +28,7 @@ License Types
 |`fivem`|CFX.re|User Id|int|
 |`ip`|IP Adress|IPv4|string|
 
-\* `licence2` - This identifier is present if the user has switched accounts
+\* `licence2` - This identifier is present if the user has switched Social Club accounts
 
 ** `license2` - This can be the same value as `license`
 

--- a/content/docs/scripting-reference/runtimes/lua/functions/GetPlayerIdentifiers.md
+++ b/content/docs/scripting-reference/runtimes/lua/functions/GetPlayerIdentifiers.md
@@ -17,16 +17,16 @@ GetPlayerIdentifiers(Player player)
 License Types
 --------
 
-|Type ID|Provider|Type|Data Type|
-|-|-|-|-|
-|`steam`|Steam|[Steam ID](https://partner.steamgames.com/doc/webapi/isteamuserauth)|hex|
-|`discord`|Discord|[User Id](https://discord.com/developers/docs/topics/oauth2#get-current-authorization-information-example-authorization-information)|int|
-|`xbl`|Xbox Live||int|
-|`live`|Microsoft PUID|Passport Unique Identifier|int|
-|`license`|Rockstar Online Services|Hash|hex|
-|`license2`|Rockstar Online Services|Hash|hex|
-|`fivem`|CFX.re|User Id|int|
-|`ip`|IP Adress|IPv4|string|
+| Type ID    | Provider                 | Type                                                                      | Data Type |
+|------------|--------------------------|---------------------------------------------------------------------------|-----------|
+| `steam`    | Steam                    | [Steam Id](https://partner.steamgames.com/doc/webapi/isteamuserauth)      | hex       |
+| `discord`  | Discord                  | [User Id](https://discord.com/developers/docs/resources/user#user-object) | int       |
+| `xbl`      | Xbox Live                |                                                                           | int       |
+| `live`     | Microsoft PUID           | Passport Unique Identifier                                                | int       |
+| `license`  | Rockstar Online Services | Hash                                                                      | hex       |
+| `license2` | Rockstar Online Services | Hash                                                                      | hex       |
+| `fivem`    | CFX.re                   | User Id                                                                   | int       |
+| `ip`       | IP Address               | IPv4                                                                      | string    |
 
 \* `licence2` - This identifier is present if the user has switched Social Club accounts
 

--- a/content/docs/scripting-reference/runtimes/lua/functions/GetPlayerIdentifiers.md
+++ b/content/docs/scripting-reference/runtimes/lua/functions/GetPlayerIdentifiers.md
@@ -25,12 +25,10 @@ License Types
 | `live`     | Microsoft PUID           | Passport Unique Identifier                                                | int       |
 | `license`  | Rockstar Online Services | Hash                                                                      | hex       |
 | `license2` | Rockstar Online Services | Hash                                                                      | hex       |
-| `fivem`    | CFX.re                   | User Id                                                                   | int       |
+| `fivem`    | Cfx.re                   | User Id                                                                   | int       |
 | `ip`       | IP Address               | IPv4                                                                      | string    |
 
-\* `licence2` - This identifier is present if the user has switched Social Club accounts
-
-** `license2` - This can be the same value as `license`
+* `license2` - This identifier is the ROS license for people who use steam, this identifier can be the same value as `license`
 
 
 Examples

--- a/content/docs/scripting-reference/runtimes/lua/functions/GetPlayerIdentifiers.md
+++ b/content/docs/scripting-reference/runtimes/lua/functions/GetPlayerIdentifiers.md
@@ -14,10 +14,29 @@ GetPlayerIdentifiers(Player player)
 ### Required arguments
 - **player**: The ID of the player to get the identifiers from.
 
+License Types
+--------
+
+|Type ID|Provider|Type|Data Type|
+|-|-|-|-|
+|`steam`|Steam|[Steam ID](https://partner.steamgames.com/doc/webapi/isteamuserauth)|hex|
+|`discord`|Discord|[User Id](https://discord.com/developers/docs/topics/oauth2#get-current-authorization-information-example-authorization-information)|int|
+|`xbl`|Xbox Live||int|
+|`live`|Microsoft PUID|Passport Unique Identifier|int|
+|`license`|Rockstar Online Services|Hash|hex|
+|`license2`|Rockstar Online Services|Hash|hex|
+|`fivem`|CFX.re|User Id|int|
+|`ip`|IP Adress|IPv4|string|
+
+\* `licence2` - This identifier is present if the user has switched accounts
+
+** `license2` - This can be the same value as `license`
+
+
 Examples
 --------
 
-Check for all possible identifiers using this method;  works well when triggered by playerConnecting event.
+Check for commonly used identifiers with this method;  works well when triggered by the `playerConnecting` event.
 
 ```lua
     local steamid  = false


### PR DESCRIPTION
These are the only license providers that I have seen.
`license2` may need to be verified to see how it's "activated". (i.e. switching SocialClub accounts or just having SocialClub multiple accounts present)