### PR TITLE
docs(natives/five): Add fuel consumption system documentation

### DIFF
--- a/content/docs/scripting-manual/_index.md
+++ b/content/docs/scripting-manual/_index.md
@@ -27,3 +27,5 @@ layout: single
   - [Loading screens](/docs/scripting-manual/nui-development/loading-screens)
 - [Using Scaleform](/docs/scripting-manual/using-scaleform)
 - [Voice](/docs/scripting-manual/voice)
+- [Using new game features](/docs/scripting-manual/using-new-game-features)
+  - [Fuel consumption](/docs/scripting-manual/using-new-game-features/fuel-consumption)

--- a/content/docs/scripting-manual/introduction/fact-sheet.md
+++ b/content/docs/scripting-manual/introduction/fact-sheet.md
@@ -24,6 +24,8 @@ The scripting manual can be found [here](/docs/scripting-manual/) and it feature
   - [Triggering events](/docs/scripting-manual/working-with-events/triggering-events)
 - [NUI](/docs/scripting-manual/nui-development)
 - [Using Scaleform](/docs/scripting-manual/using-scaleform)
+- [Voice](/docs/scripting-manual/voice)
+- [Using new game features](/docs/scripting-manual/using-new-game-features)
 
 You can refer to the page mentioned above to see the scripting manual in full detail.
 

--- a/content/docs/scripting-manual/using-new-game-features/_index.md
+++ b/content/docs/scripting-manual/using-new-game-features/_index.md
@@ -1,0 +1,8 @@
+---
+title: Using new game features
+weight: 420
+---
+
+FiveM adds new features to the original game. Documentation on how to utilize some of the latest ones in your game can be found in this section.
+
+- [Fuel consumption](/docs/scripting-manual/using-new-game-features/fuel-consumption)

--- a/content/docs/scripting-manual/using-new-game-features/fuel-consumption.md
+++ b/content/docs/scripting-manual/using-new-game-features/fuel-consumption.md
@@ -124,11 +124,11 @@ function IsPlayerInVehicleAtGasStation(vehicle)
     return false
 end
 
-Citizen.CreateThread(function()
+CreateThread(function()
     -- Main loop.
     while true do
         -- Do not add sleep time since this thread is operating with controls.
-        Citizen.Wait(0)
+        Wait(0)
 
         -- Only run script if fuel consumption is turned on globally.
         if GetFuelConsumptionState() then

--- a/content/docs/scripting-manual/using-new-game-features/fuel-consumption.md
+++ b/content/docs/scripting-manual/using-new-game-features/fuel-consumption.md
@@ -1,0 +1,151 @@
+---
+title: Fuel consumption
+weight: 421
+---
+
+By default in GTA5 and FiveM vehicles do not consume fuel. This feature allows to turn the fuel consumption on and customize it for your needs.
+
+### Turn on/off
+
+To set/check the fuel consumption use [`SET_FUEL_CONSUMPTION_STATE`](https://docs.fivem.net/natives/?_0x81DAD03E)/[`GET_FUEL_CONSUMPTION_STATE`](https://docs.fivem.net/natives/?_0xC66CD90C) natives. Set true to turn it on, false - to turn it off.
+
+### How it works
+
+#### Fuel consumption speed
+
+When turned on, fuel consumption is calculated by the formula:
+
+```
+time_step * revolutions_per_minute * vehicle_fuel_consumption_rate_multiplier * global_fuel_consumption_rate_multiplier
+```
+
+I.e. fuel is consumed faster the more revolutions engine does. This approximates how fuel consumption works in real world.
+
+Fuel is not consumed when the engine is turned off.
+
+By default, 65 litre gas tank car with average fuel consumption can stay **idle for ~16.67 hours** or run with **max RPM for ~2.5 hours**.
+
+#### Customize consumption speed
+
+To customize/check global (across all vehicles) fuel consumption rate (`global_fuel_consumption_rate_multiplier` in the formula above) use [`SET_FUEL_CONSUMPTION_RATE_MULTIPLIER`](https://docs.fivem.net/natives/?_0x845F3E5C)/[`GET_FUEL_CONSUMPTION_RATE_MULTIPLIER`](https://docs.fivem.net/natives/?_0x5550BF9F) natives. By default it is set to 1. If set to negative - 0 will be used instead.
+
+To customize fuel consumption per vehicle (`vehicle_fuel_consumption_rate_multiplier` in the formula above) use [`SET_HANDLING_FLOAT`](https://docs.fivem.net/natives/?_0x90DD01C) (for all vehicles with given class) or [`SET_VEHICLE_HANDLING_FLOAT`](https://docs.fivem.net/natives/?_0x488C86D2) (for a specific vehicle) native with `fieldName` equal to `fPetrolConsumptionRate`. By default it is set to 0.5 for all vehicles.
+
+You can also use [CodeWalker](https://github.com/dexyfex/CodeWalker) tool or similar to edit vehicle `handling.meta` file and set `fPetrolConsumptionRate` value to `HandlingData`. If not set it results to the default value of 0.5.
+
+#### Petrol tank volume and current fuel level
+
+To customize petrol tank volume use [`SET_HANDLING_FLOAT`](https://docs.fivem.net/natives/?_0x90DD01C)/[`SET_VEHICLE_HANDLING_FLOAT`](https://docs.fivem.net/natives/?_0x488C86D2) natives with `fieldName` equal to `fPetrolTankVolume`.
+
+You can also use [CodeWalker](https://github.com/dexyfex/CodeWalker) tool or similar to edit vehicle `handling.meta` file and set `fPetrolTankVolume` value to `HandlingData`.
+
+To update/check fuel level in a vehicle use [`GET_VEHICLE_FUEL_LEVEL`](https://docs.fivem.net/natives/?_0x5F739BB8)/[`SET_VEHICLE_FUEL_LEVEL`](https://docs.fivem.net/natives/?_0xBA970511) natives.
+
+#### Vehicles without fuel consumption
+
+Fuel is not consumed for the following vehicles:
+
+- Vehicles that only have NPCs in them.
+- Bicycles. I.e. vehicles with vehicle type equal to 12.
+- Vehicles with infinite fuel. I.e. vehicles with petrol tank volume equal to 0. By default it's only bicycles.
+
+To check if vehicle will consume fuel when player is inside (i.e. petrol tank volume above 0 and not a bicycle) use [`DOES_VEHICLE_USE_FUEL`](https://docs.fivem.net/natives/?_0xEF30A696) native.
+
+### Gas stations
+
+When turning on fuel consumption you need to think about mechanisms to allow players to refuel a vehicle.
+
+We do not provide out of the box functionality for gas stations. But you can implement it on your own using provided natives.
+
+#### Example gas stations implementation
+
+```lua
+-- List of all gas stations in the world.
+-- Update this list to include all gas station locations.
+-- You can create a config file and read it from there, or just hard code as in this example.
+GasStations = {
+    {
+        coords = vector3(64.55, 20.4, 68.9),  
+        radius = 8
+    }
+}
+
+-- Distance from point is the simplest way to determine if vehicle is at a gas station.
+-- You can use polygons if you need more precision.
+function IsPointInGasStation(point, gasStation)
+    return #(point - gasStation.coords) <= gasStation.radius
+end
+
+-- Triggered when player enters gas station.
+-- You can customize communication with a player the way you want.
+function ProcessGasStationEnter(vehicle)
+    -- Get current vehicle fuel level.
+    local vehicleFuelLevel = GetVehicleFuelLevel(vehicle)
+    -- Get vehicle petrol tank volume.
+    local vehicleGasTankVolume = GetVehicleHandlingFloat(vehicle, "CHandlingData", "fPetrolTankVolume")
+    -- Display basic text message.
+    local gasStationMessage = string.format("Welcome to gas station. You have %.3f out of %.3f liters of fuel left. Press G to fill tank.", vehicleFuelLevel, vehicleGasTankVolume)
+    AddTextEntry("CH_ALERT", gasStationMessage)
+    BeginTextCommandDisplayHelp("CH_ALERT")
+    EndTextCommandDisplayHelp(0, false, false, 200)
+end
+
+-- Fill up player's vehicle gas tank.
+-- You can customize communication with a player the way you want.
+function ProcessGasStationFuelPurchase(vehicle)
+    -- Get vehicle petrol tank volume.
+    local vehicleGasTankVolume = GetVehicleHandlingFloat(vehicle, "CHandlingData", "fPetrolTankVolume")
+    -- Fill up the tank.
+    SetVehicleFuelLevel(vehicle, vehicleGasTankVolume)
+end
+
+function IsPlayerInVehicleAtGasStation(vehicle)
+    local playerPed = PlayerPedId()
+    if not playerPed or playerPed == -1 then
+        return false
+    end
+
+    -- If a player is not in a vehicle.
+    local vehicle = GetVehiclePedIsIn(playerPed, false)
+    if not vehicle or not DoesEntityExist(vehicle) then
+        return false
+    end
+
+    -- If the vehicle doesn't use fuel (i.e. a bicycle or with infinite fuel).
+    if not DoesVehicleUseFuel(vehicle) then
+        return false
+    end
+
+    -- Get coordinates of the vehicle and check that it's close enough to any of the gas stations.
+    local vehicleCoords = GetEntityCoords(playerPed)
+    for _, gasStation in ipairs(GasStations) do
+        if IsPointInGasStation(vehicleCoords, gasStation) then
+            return true
+        end
+    end
+
+    return false
+end
+
+Citizen.CreateThread(function()
+    -- Main loop.
+    while true do
+        Citizen.Wait(50)
+
+        -- Only run script if fuel consumption is turned on globally.
+        if GetFuelConsumptionState() then
+            if IsPlayerInVehicleAtGasStation() then
+
+                local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
+
+                ProcessGasStationEnter(vehicle)
+
+                -- If G is pressed on a keyboard.
+                if IsControlPressed(0, 58) then
+                    ProcessGasStationFuelPurchase(vehicle)
+                end
+            end
+        end
+    end
+end)
+```

--- a/content/docs/scripting-manual/using-new-game-features/fuel-consumption.md
+++ b/content/docs/scripting-manual/using-new-game-features/fuel-consumption.md
@@ -99,28 +99,21 @@ function ProcessGasStationFuelPurchase(vehicle)
     SetVehicleFuelLevel(vehicle, vehicleGasTankVolume)
 end
 
-function IsPlayerInVehicleAtGasStation(vehicle)
-    local playerPed = PlayerPedId()
-
-    -- If a player is not in a vehicle.
-    local vehicle = GetVehiclePedIsIn(playerPed, false)
-    if vehicle == 0 or not DoesEntityExist(vehicle) then
-        return false
-    end
-
+-- Checks if the specified vehicle is close to a gas station.
+-- Caller must ensure that the vehicle exists.
+function IsVehicleAtGasStation(vehicle)
     -- If the vehicle doesn't use fuel (i.e. a bicycle or with infinite fuel).
     if not DoesVehicleUseFuel(vehicle) then
         return false
     end
 
     -- Get coordinates of the vehicle and check that it's close enough to any of the gas stations.
-    local vehicleCoords = GetEntityCoords(playerPed)
+    local vehicleCoords = GetEntityCoords(vehicle)
     for _, gasStation in ipairs(GasStations) do
         if IsPointInGasStation(vehicleCoords, gasStation) then
             return true
         end
     end
-
     return false
 end
 
@@ -132,15 +125,19 @@ CreateThread(function()
 
         -- Only run script if fuel consumption is turned on globally.
         if GetFuelConsumptionState() then
-            if IsPlayerInVehicleAtGasStation() then
 
-                local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
+            -- Check if player is in a vehicle.
+            local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
+            if DoesEntityExist(vehicle) then
 
-                ProcessGasStationEnter(vehicle)
+                if IsVehicleAtGasStation(vehicle) then
 
-                -- If G is pressed on a keyboard.
-                if IsControlPressed(0, 58) then
-                    ProcessGasStationFuelPurchase(vehicle)
+                    ProcessGasStationEnter(vehicle)
+
+                    -- If G is pressed on a keyboard.
+                    if IsControlPressed(0, 58) then
+                        ProcessGasStationFuelPurchase(vehicle)
+                    end
                 end
             end
         end

--- a/content/docs/scripting-manual/using-new-game-features/fuel-consumption.md
+++ b/content/docs/scripting-manual/using-new-game-features/fuel-consumption.md
@@ -101,13 +101,13 @@ end
 
 function IsPlayerInVehicleAtGasStation(vehicle)
     local playerPed = PlayerPedId()
-    if not playerPed or playerPed == -1 then
+    if playerPed == 0 or playerPed == -1 then
         return false
     end
 
     -- If a player is not in a vehicle.
     local vehicle = GetVehiclePedIsIn(playerPed, false)
-    if not vehicle or not DoesEntityExist(vehicle) then
+    if vehicle == 0 or not DoesEntityExist(vehicle) then
         return false
     end
 
@@ -130,7 +130,8 @@ end
 Citizen.CreateThread(function()
     -- Main loop.
     while true do
-        Citizen.Wait(50)
+        -- Do not add sleep time since this thread is operating with controls.
+        Citizen.Wait(0)
 
         -- Only run script if fuel consumption is turned on globally.
         if GetFuelConsumptionState() then

--- a/content/docs/scripting-manual/using-new-game-features/fuel-consumption.md
+++ b/content/docs/scripting-manual/using-new-game-features/fuel-consumption.md
@@ -101,9 +101,6 @@ end
 
 function IsPlayerInVehicleAtGasStation(vehicle)
     local playerPed = PlayerPedId()
-    if playerPed == 0 or playerPed == -1 then
-        return false
-    end
 
     -- If a player is not in a vehicle.
     local vehicle = GetVehiclePedIsIn(playerPed, false)

--- a/content/docs/scripting-manual/using-new-game-features/fuel-consumption.md
+++ b/content/docs/scripting-manual/using-new-game-features/fuel-consumption.md
@@ -23,7 +23,7 @@ I.e. fuel is consumed faster the more revolutions engine does. This approximates
 
 Fuel is not consumed when the engine is turned off.
 
-By default, 65 litre gas tank car with average fuel consumption can stay **idle for ~16.67 hours** or run with **max RPM for ~2.5 hours**.
+By default, 65 liter gas tank car with average fuel consumption can stay **idle for ~16.67 hours** or run with **max RPM for ~2.5 hours**.
 
 #### Customize consumption speed
 


### PR DESCRIPTION
Documentation for the following set of commits (fuel consumption system implementation):
- https://github.com/citizenfx/fivem/commit/ae65681e39b1bacf5c6fd2d0a98366003fc1d6a6
- https://github.com/citizenfx/fivem/commit/c4d2f2b2d7ce08cc345adc50b5911bd69c041999
- https://github.com/citizenfx/fivem/commit/efd1390c6f9484b9fe57ea8aaddee9a557c6c747
- https://github.com/citizenfx/fivem/commit/4ba5737f9aaf6382de5b103b029c5575e653e162

FYI: links to the new natives may not work because the natives documentation has not propagated to the docs.fivem.net yet.