### PR TITLE
tweak(docs/commands): add a note that rcon uses UDP

### DIFF
--- a/content/docs/server-manual/server-commands.md
+++ b/content/docs/server-manual/server-commands.md
@@ -366,7 +366,7 @@ load_server_icon "my-server.png"
 
 ### `rcon_password [password]`
 
-Sets the RCon password. This being unset means RCon is disabled.
+Sets the RCon password, if unset then RCon will be disabled. FXServer RCon uses UDP.
 
 ### `steam_webApiKey [key]`
 


### PR DESCRIPTION
- This came up in a conversation with Yorick in txAdmin, the docs never specify that rcon uses UDP