### PR TITLE
tweak(docs/links): use cfx articles

### DIFF
--- a/content/docs/client-manual/_index.md
+++ b/content/docs/client-manual/_index.md
@@ -6,7 +6,8 @@ layout: single
 
 Basics
 ------
-- [Installing FiveM](/docs/client-manual/installing-fivem)
+- [Installing FiveM](https://support.cfx.re/hc/en-us/articles/360020992639-Installing-FiveM)
+- [CFX articles](https://support.cfx.re/hc/en-us/sections/360005606960-FiveM)
 - [Console commands](/docs/client-manual/console-commands)
 - [CitizenFX.ini](/docs/client-manual/citizenfx)
 
@@ -39,4 +40,4 @@ The server browser allows for some neat searching tricks:
 
 Troubleshooting issues
 ----------------------
-Are you running into issues? Read the dedicated [troubleshooting manual](/docs/support/client-issues).
+Are you running into issues? Read the dedicated [troubleshooting manual](/docs/support/client-issues). You can also check out common errors [here](https://support.cfx.re/hc/en-us/sections/5299954457756-Common-errors).

--- a/content/docs/client-manual/console-commands.md
+++ b/content/docs/client-manual/console-commands.md
@@ -390,6 +390,6 @@ Usage: `test_ace <principal> <object>`
 
 Example: `test_ace group.admin command.adminstuff`
 
-[faq-data]: /docs/support/client-faq#where-is-fivem-installed
+[faq-data]: https://support.cfx.re/hc/en-us/articles/8016397932444-Client-FAQ#where-is-fivem-installed
 [vconsole]: https://forum.cfx.re/t/20005
 [manifest-reference]: /docs/scripting-reference/resource-manifest/resource-manifest/

--- a/content/docs/client-manual/installing-fivem.md
+++ b/content/docs/client-manual/installing-fivem.md
@@ -1,6 +1,7 @@
 ---
 title: Installing FiveM
 weight: 240
+toc_hide: true
 ---
 
 Installing FiveM is pretty straightforward. It's usually a matter of [downloading FiveM][home], then simply running the

--- a/content/docs/client-manual/system-requirements.md
+++ b/content/docs/client-manual/system-requirements.md
@@ -1,6 +1,7 @@
 ---
 title: System requirements
 weight: 220
+toc_hide: true
 ---
 
 To [run FiveM][installing] your system must meet the [minimum requirements of the original game][gtav-system-specs].

--- a/content/docs/client-manual/where-to-buy-gtav.md
+++ b/content/docs/client-manual/where-to-buy-gtav.md
@@ -1,6 +1,7 @@
 ---
 title: Where to buy GTA V
 weight: 210
+toc_hide: true
 ---
 
 FiveM requires a fully updated installation of GTA V. If you do not own a legal copy of GTA V yet, you can buy it from

--- a/content/docs/fxdk/_index.md
+++ b/content/docs/fxdk/_index.md
@@ -50,7 +50,7 @@ In FxDK, [building](/docs/fxdk/project-building) deploy-ready server is as easy 
 
 > If you have FiveM installed - skip to step 2.
 
-1. [Install FiveM](/docs/client-manual/installing-fivem).
+1. [Install FiveM](https://support.cfx.re/hc/en-us/articles/360020992639-Installing-FiveM).
 2. Next to `FiveM.exe` you'll find a shortcut named `FiveM - Cfx.re Development Kit (FxDK)`.
 3. Follow intro or skip and start creating right away.
 

--- a/content/docs/support/_index.md
+++ b/content/docs/support/_index.md
@@ -4,7 +4,7 @@ weight: 800
 layout: single
 ---
 
-- [Client FAQ](/docs/support/client-faq)
+- [Client FAQ](https://support.cfx.re/hc/en-us/articles/8016397932444-Client-FAQ)
 - [Client issues](/docs/support/client-issues)
 - [Server issues](/docs/support/server-issues)
 - [Server debugging](/docs/support/server-debug)

--- a/content/docs/support/client-issues.md
+++ b/content/docs/support/client-issues.md
@@ -111,14 +111,14 @@ Help! I can't find my issue here!
 We're here to help! First, check the Cfx.re support [section][support-game-articles] for your issue. If you're experiencing crashes or freezes, please post your details on our [forums][forum-tech-support] to help us assist you better.
 For all other inquiries, feel free to join our [Discord][discord] for a chat!
 
-[where-is-fivem-installed]: /docs/support/client-faq#where-is-fivem-installed
+[where-is-fivem-installed]: https://support.cfx.re/hc/en-us/articles/8016397932444-Client-FAQ#where-is-fivem-installed
 [antivirus-ticket]: https://support.cfx.re/hc/en-us/requests/new
 [email]: mailto:support@fivem.net
 [forum]: https://forum.cfx.re
 [forum-tech-support]: https://forum.cfx.re/c/technical-support
 [discord]: https://discord.gg/fivem
-[testing-server]: https://cfx.re/join/7b6bor
-[uninstalling]: /docs/client-manual/installing-fivem#uninstalling
+[testing-server]: https://cfx.re/join/jm85gm
+[uninstalling]: https://support.cfx.re/hc/en-us/articles/360020967780-Uninstalling-FiveM
 [discrete-gpu]: https://forum.cfx.re/t/217731
 [support-create-etw-trace]: https://support.cfx.re/hc/en-us/articles/8366604193436-Creating-an-ETW-trace
 [support-ban-faq]: https://support.cfx.re/hc/en-us/articles/8444465475356-Bans-FAQ


### PR DESCRIPTION
Goal here is to slowly remove all the client manual to fully support the [CFX articles pages](https://support.cfx.re/hc/en-us/sections/360005606960-FiveM).

Docs shouldn't support client issues, otherwhise the article pages wouldn't be necessary. 


Please note that some issue with informations in articles have been reported in the Engineering group. For the PR, it's explain in the commit.