### PR TITLE
feat(page/doc): custom 404 page

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,9 @@
+{{ define "main" }}
+  <h1>404 | Page not found</h1>
+  <p>If you got redirected from a doc page, please report this issue <a href="https://github.com/citizenfx/fivem-docs/issues/new">here</a>.</p>
+  <p>
+    <a href="https://docs.fivem.net/docs/">
+      Return to the home page
+    </a>
+  </p>
+{{ end }}


### PR DESCRIPTION
Should be handle following https://gohugo.io/templates/404/

Will also handle Github issue if someone found a invalid link

Issue is people that goes into 404 page can't "return home".

![image](https://github.com/citizenfx/fivem-docs/assets/94499608/b5aa9979-a3e0-41b3-9bdc-7b661a488ace)
