### PR TITLE
game-events.md added description for CEventShockingFire

### DIFF
--- a/content/docs/game-references/game-events.md
+++ b/content/docs/game-references/game-events.md
@@ -228,7 +228,7 @@ useful information to share, please [add it to this doc][contributing]. Any help
 | CEventShockingDrivingOnPavement                    |             |
 | CEventShockingEngineRevved                         |             |
 | CEventShockingExplosion                            |             |
-| CEventShockingFire                                 |             |
+| CEventShockingFire                                 |Is triggered when a fire is changing (being created, spreading). Returns: 1. Table including handles of nearby peds reacting to the fire. Seems to return only one tho and trigger again for other peds. 2. The handle of the entity that is set on fire, 0 if none. 3. coords of the fire as array.|
 | CEventShockingGunFight                             |             |
 | CEventShockingGunshotFired                         |             |
 | CEventShockingHelicopterOverhead                   |             |


### PR DESCRIPTION
I added a description for CEventShockingFire, including the returned values and the trigger. I found this out by testing myself. I tried to test it as thouroughly as I could. I don't know if the formatting is ideal for this repo, change it if needed.