### PR TITLE
feat(net): support dynamic server endpoints using handover

### DIFF
--- a/content/docs/scripting-reference/events/list/playerConnecting.md
+++ b/content/docs/scripting-reference/events/list/playerConnecting.md
@@ -49,6 +49,17 @@ prior deferral method.
 If `failureReason` is specified, the connection will be refused, and the user will see the specified message as a result.
 If this is not specified, the user will be allowed to connect.
 
+#### Dynamic handover
+
+`deferrals.handover` will allow you to set in a table the enpoints for a specific player on connection.
+
+This will look like this:
+```lua
+deferrals.handover({
+    endpoints = { "127.0.0.1" }
+})
+```
+
 Examples
 --------
 This example checks a connecting player's license identifier against a ban list. If the player is in the ban list, they get kicked, otherwise they are allowed to connect.


### PR DESCRIPTION
Allow the server to pass a specific pure mode level or an endpoint using deferrals to a specific player and show the example how to.

Please note this is related to [this pr](https://github.com/citizenfx/fivem/pull/2625) made by @PichotM and was talk with members in intern. Only merge when the original feature is commited.