### PR TITLE
Disable Antivirus scanning on FXServer directories

### DIFF
--- a/content/docs/server-manual/setting-up-a-server-txadmin.md
+++ b/content/docs/server-manual/setting-up-a-server-txadmin.md
@@ -48,6 +48,8 @@ description: >
 14. ... and finally, "Save & Run Server", and you're done!<br>
    ![pic](/server-setup/windows-step2-14.png)
 
+#### Troubleshooting
+If you're facing slow server startups, refer to [this][slow-server-startups].
 
 [windows-artifacts]: https://runtime.fivem.net/artifacts/fivem/build_server_windows/master/
 [server-data]: https://github.com/citizenfx/cfx-server-data
@@ -56,3 +58,4 @@ description: >
 
 [winrar]: https://www.rarlab.com/download.htm
 [7zip]: https://www.7-zip.org/download.html
+[slow-server-startups]: /docs/support/server-issues/#troubleshooting-slow-server-startups-on-windows

--- a/content/docs/server-manual/setting-up-a-server-vanilla.md
+++ b/content/docs/server-manual/setting-up-a-server-vanilla.md
@@ -70,6 +70,7 @@ An example server.cfg follows.
 - If you don't get any 'resources found', and it says 'Failed to start resource', you didn't 'cd' to the right folder.
 - If no resources get started, and you also can't connect (i.e. 'timed out'/'connection refused'), you didn't add +exec.
 - If you get 'no license key was specified', one of the above two mistakes may apply.
+- If you're facing slow server startups on Windows, refer to [this][slow-server-startups].
 
 [windows-artifacts]: https://runtime.fivem.net/artifacts/fivem/build_server_windows/master/
 [linux-artifacts]: https://runtime.fivem.net/artifacts/fivem/build_proot_linux/master/
@@ -79,4 +80,5 @@ An example server.cfg follows.
 [winrar]: https://www.rarlab.com/download.htm
 [7zip]: https://www.7-zip.org/download.html
 [git-scm]: https://git-scm.com/download/win
+[slow-server-startups]: /docs/support/server-issues/#troubleshooting-slow-server-startups-on-windows
 

--- a/content/docs/support/server-issues.md
+++ b/content/docs/support/server-issues.md
@@ -89,6 +89,19 @@ You may be experiencing this in different cases. For example, the server colors 
 3. Didn't save and/or restart server
 4. Server list cache hasn't updated, be patient
 
+Troubleshooting Slow Server Startups on Windows
+---------------------------------
+
+On Windows, Microsoft Defender Antivirus can slow down server startups by scanning files within your FXServer directory. To mitigate this issue, you can add your server folder to the exclusion list. 
+
+Launch PowerShell as an administrator and execute the following command, replacing `'C:\FXServer\'` with the actual path to your FXServer directory:
+
+```
+Add-MpPreference -ExclusionPath 'C:\FXServer\'
+```
+
+For more details on the `Add-MpPreference` command, refer to the [official documentation][add-mp-preference-docs].
+
 Help! I can't find my issue here!
 ---------------------------------
 
@@ -103,3 +116,4 @@ You can also join our [Discord][discord] and have a chat with us.
 [servercfg]: /docs/server-manual/setting-up-a-server-vanilla/#servercfg
 [chat-formatting]: https://forum.cfx.re/t/67641
 [setting-up-server]: /docs/server-manual/setting-up-a-server
+[add-mp-preference-docs]: https://learn.microsoft.com/en-us/powershell/module/defender/add-mppreference


### PR DESCRIPTION
This commit adds a notice to guide users on creating an exclusion path for Microsoft Defender Antivirus to prevent it from scanning their FXServer directory.

The notice is included in the server-issues section and referenced in both the vanilla and txAdmin server setup guides.

This change addresses issue #455. However, I believe it would be more appropriately placed under the "Cfx.re Platform Server (FXServer)" section located at https://support.cfx.re/hc/en-us/sections/8856844172188-Cfx-re-Platform-Server-FXServer.