### PR TITLE
docs(natives/five): Add general overview documentation for the new collection-based natives

### DIFF
--- a/content/docs/scripting-manual/_index.md
+++ b/content/docs/scripting-manual/_index.md
@@ -29,3 +29,4 @@ layout: single
 - [Voice](/docs/scripting-manual/voice)
 - [Using new game features](/docs/scripting-manual/using-new-game-features)
   - [Fuel consumption](/docs/scripting-manual/using-new-game-features/fuel-consumption)
+  - [Collection based natives](/docs/scripting-manual/using-new-game-features/collection-based-natives)

--- a/content/docs/scripting-manual/_index.md
+++ b/content/docs/scripting-manual/_index.md
@@ -29,4 +29,4 @@ layout: single
 - [Voice](/docs/scripting-manual/voice)
 - [Using new game features](/docs/scripting-manual/using-new-game-features)
   - [Fuel consumption](/docs/scripting-manual/using-new-game-features/fuel-consumption)
-  - [Collection based natives](/docs/scripting-manual/using-new-game-features/collection-based-natives)
+  - [Collection-based natives](/docs/scripting-manual/using-new-game-features/collection-based-natives)

--- a/content/docs/scripting-manual/using-new-game-features/_index.md
+++ b/content/docs/scripting-manual/using-new-game-features/_index.md
@@ -6,3 +6,4 @@ weight: 420
 FiveM adds new features to the original game. Documentation on how to utilize some of the latest ones in your game can be found in this section.
 
 - [Fuel consumption](/docs/scripting-manual/using-new-game-features/fuel-consumption)
+- [Work with drawable components and props using collections](/docs/scripting-manual/using-new-game-features/collection-based-natives)

--- a/content/docs/scripting-manual/using-new-game-features/collection-based-natives.md
+++ b/content/docs/scripting-manual/using-new-game-features/collection-based-natives.md
@@ -1,0 +1,215 @@
+---
+title: Work with drawable components and props using collections
+weight: 421
+---
+
+Inside the GTA5 Ped drawable components and props are stored in named groups called collections. However, collections were previously unavailable for FiveM users. The drawable components and props were indexed through global index. On every TU (Title Update) the global index of custom drawable components and props would change (see below for more details on why it happens). This complicates migration to the latest game build.
+
+The new set of natives allows accessing drawable components and props through collections. The collection-based indexes remain stable after TUs. **So using these natives will simplify all future TU updates for a server.**
+
+    Note: The new natives are currently available for GTA5 and on client side only.
+
+### How drawable components and props indexing works
+
+    Note: Drawable components and props are stored in Ped in the same way. Below we will refer to drawable components / drawables only.
+
+You can think of collections in Ped as list of buckets placed one after another. Each collection is named and contains multiple drawables.
+
+**Global index** is an index of drawable starting from the beginning of the set. **Local index** is an index of drawable starting from the beginning of each collection.
+
+E.g.:
+
+<table><tbody>
+  <tr>
+    <td></td>
+    <td colspan="9">Official GTA5 collections</td>
+    <td colspan="3">Custom collections</td>
+  </tr>
+  <tr>
+    <td>Collection names</td>
+    <td colspan="2">""</td>
+    <td colspan="4">"feemale_freemode_beach"</td>
+    <td colspan="3">"feemale_xmas"</td>
+    <td colspan="3">"custom_collection"</td>
+  </tr>
+  <tr>
+    <td>Local indexes</td>
+    <td>0</td>
+    <td>1</td>
+    <td>0</td>
+    <td>1</td>
+    <td>2</td>
+    <td>3</td>
+    <td>0</td>
+    <td>1</td>
+    <td>2</td>
+    <td>0</td>
+    <td>1</td>
+    <td>2</td>
+  </tr>
+  <tr>
+    <td>Global indexes</td>
+    <td>0</td>
+    <td>1</td>
+    <td>2</td>
+    <td>3</td>
+    <td>4</td>
+    <td>5</td>
+    <td>6</td>
+    <td>7</td>
+    <td>8</td>
+    <td>9</td>
+    <td>10</td>
+    <td>11</td>
+  </tr>
+</tbody>
+</table>
+
+#### Where collection name is set
+
+The first collection corresponds to the base game (without any DLCs). After the base game collection follow collection that correspond to official DLCs. Custom collections are added to the end.
+
+After TU is released and new official DLC collection is added - all custom collections are shifted. So, the global indexes that correspond to custom collections shift and must be updated on every TU. While the indexes that are relative to the beginning of a collection will remain stable after TU.
+
+The base game name collection is an empty string. Names of other collections are set by `<CPedVariationInfo name="...">` tag of the corresponding `.ymt` file. E.g. see `Grand Theft Auto V\update\x64\dlcpacks\mp2024_01\dlc.rpf\x64\models\cdimages\mp2024_01_female.rpf\mp_f_freemode_01_mp_f_2024_01.ymt` base game file.
+
+### New natives
+
+There are three groups of new natives:
+- Natives to get general information about collections 
+- Natives to convert between global and local indexes.
+- Natives that are analogues to the existing natives that work with drawable components and props. But instead of working with global indexes thy work with collection names and local indexes.
+
+#### General info natives
+
+- [GET_PED_COLLECTIONS_COUNT](https://docs.fivem.net/natives/?_0x45946359) - get total number of collections available for Ped
+- [GET_PED_COLLECTION_NAME](https://docs.fivem.net/natives/?_0xFED5D83A) - get collection name by collection number
+
+#### Conversion between global and local indexing
+
+- [GET_PED_COLLECTION_NAME_FROM_DRAWABLE](https://docs.fivem.net/natives/?_0xD6BBA48B), [GET_PED_COLLECTION_LOCAL_INDEX_FROM_DRAWABLE](https://docs.fivem.net/natives/?_0x94EB1FE4) - get collection name and local index from global drawable index
+- [GET_PED_COLLECTION_NAME_FROM_PROP](https://docs.fivem.net/natives/?_0x8ED0C17), [GET_PED_COLLECTION_LOCAL_INDEX_FROM_PROP](https://docs.fivem.net/natives/?_0xFBDB885F) - get collection name and local index from global prop index
+- [GET_PED_DRAWABLE_GLOBAL_INDEX_FROM_COLLECTION](https://docs.fivem.net/natives/?_0x280F1FC3) - get global drawable index from collection name and local index
+- [GET_PED_PROP_GLOBAL_INDEX_FROM_COLLECTION](https://docs.fivem.net/natives/?_0x2CB45CDC) - get global prop index from collection name and local index
+
+#### Analogues to existing natives
+
+| Old (global index based) native | New (collection-based) native |
+| ---------- | ---------- |
+| [SET_PED_COMPONENT_VARIATION](https://docs.fivem.net/natives/?_0x262B14F48D29DE80) | [SET_PED_COLLECTION_COMPONENT_VARIATION](https://docs.fivem.net/natives/?_0x88711BBA) |
+| [SET_PED_PROP_INDEX](https://docs.fivem.net/natives/?_0x93376B65A266EB5F) | [SET_PED_COLLECTION_PROP_INDEX](https://docs.fivem.net/natives/?_0x75240BCB) |
+| [SET_PED_PRELOAD_VARIATION_DATA](https://docs.fivem.net/natives/?_0x39D55A620FCB6A3A) | [SET_PED_COLLECTION_PRELOAD_VARIATION_DATA](https://docs.fivem.net/natives/?_0x3EC75558) |
+| [SET_PED_PRELOAD_PROP_DATA](https://docs.fivem.net/natives/?_0x2B16A3BFF1FBCE49) | [SET_PED_COLLECTION_PRELOAD_PROP_DATA](https://docs.fivem.net/natives/?_0x14B5BBE0) |
+| [GET_NUMBER_OF_PED_DRAWABLE_VARIATIONS](https://docs.fivem.net/natives/?_0x27561561732A7842) | [GET_NUMBER_OF_PED_COLLECTION_DRAWABLE_VARIATIONS](https://docs.fivem.net/natives/?_0x310D0271) |
+| [GET_NUMBER_OF_PED_PROP_DRAWABLE_VARIATIONS](https://docs.fivem.net/natives/?_0x5FAF9754E789FB47) | [GET_NUMBER_OF_PED_COLLECTION_PROP_DRAWABLE_VARIATIONS](https://docs.fivem.net/natives/?_0x3B6A13E1) |
+| [GET_NUMBER_OF_PED_TEXTURE_VARIATIONS](https://docs.fivem.net/natives/?_0x8F7156A3142A6BAD) | [GET_NUMBER_OF_PED_COLLECTION_TEXTURE_VARIATIONS](https://docs.fivem.net/natives/?_0xD2C15D7) |
+| [GET_NUMBER_OF_PED_PROP_TEXTURE_VARIATIONS](https://docs.fivem.net/natives/?_0xA6E7F1CEB523E171) | [GET_NUMBER_OF_PED_COLLECTION_PROP_TEXTURE_VARIATIONS](https://docs.fivem.net/natives/?_0x75CAF9CC) |
+| [IS_PED_COMPONENT_VARIATION_VALID](https://docs.fivem.net/natives/?_0xE825F6B6CEA7671D) | [IS_PED_COLLECTION_COMPONENT_VARIATION_VALID](https://docs.fivem.net/natives/?_0xCA63A52A) |
+| [IS_PED_COMPONENT_VARIATION_GEN9_EXCLUSIVE](https://docs.fivem.net/natives/?_0xC767B581) | [IS_PED_COLLECTION_COMPONENT_VARIATION_GEN9_EXCLUSIVE](https://docs.fivem.net/natives/?_0x33B2AFA2) |
+| [GET_PED_DRAWABLE_VARIATION](https://docs.fivem.net/natives/?_0x67F3780DD425D4FC) | [GET_PED_DRAWABLE_VARIATION_COLLECTION_LOCAL_INDEX](https://docs.fivem.net/natives/?_0x9970386F) |
+| [GET_PED_DRAWABLE_VARIATION](https://docs.fivem.net/natives/?_0x67F3780DD425D4FC) | [GET_PED_DRAWABLE_VARIATION_COLLECTION_NAME](https://docs.fivem.net/natives/?_0xBCE0AB63) |
+
+### Examples
+
+Below are some example lua scripts that illustrate usage of the new natives.
+
+Listing all collections available for ped and number of component and prop drawable variations available in each collection:
+
+```lua
+function printFullCollectionInfo(ped, collectionName)
+    print(string.format("   Name: \"%s\"", collectionName))
+
+    print("   Number of drawable variations per component number:")
+    -- See https://docs.fivem.net/natives/?_0x262B14F48D29DE80 for the list of all components.
+    for i = 0, 12 do
+        local drawableVariationsCount = GetNumberOfPedCollectionDrawableVariations(ped, i, collectionName)
+        print(string.format("       For component %d: %d", i, drawableVariationsCount))
+    end
+
+    print("   Number of drawable variations per anchor point:")
+    -- See https://docs.fivem.net/natives/?_0x93376B65A266EB5F for the list of all anchor points.
+    for i = 0, 12 do
+        local drawablePropVariationsCount = GetNumberOfPedCollectionPropDrawableVariations(ped, i, collectionName)
+        print(string.format("       For anchor %d: %d", i, drawablePropVariationsCount))
+    end
+end
+
+function printFullCollectionsInfo(ped)
+    local collectionsCount = GetPedCollectionsCount(ped)
+    print(string.format("Found %d collections", collectionsCount))
+    for i = 0, collectionsCount - 1 do
+        local collectionName = GetPedCollectionName(ped, i)
+
+        print(string.format("Collection %d", i))
+        printFullCollectionInfo(ped, collectionName)
+    end
+end
+
+RegisterCommand('PrintFullPlayerPedCollectionsInfo', function(source)
+    local playerPed = PlayerPedId()
+    printFullCollectionsInfo(playerPed)
+end, true)
+```
+
+Set new ped look (for `mp_f_freemode_01` ped model, see https://docs.fivem.net/docs/game-references/ped-models/, other models may have less drawable variations available):
+
+```lua
+function setLook(ped)
+    -- Use head (component id 0) from base game collection (empty string) and local index 27.
+    -- Base game collection indexes and global indexes are the same (see documentation above).
+    -- Same as SetPedComponentVariation(ped, 0, 27, 0, 0)
+    SetPedCollectionComponentVariation(ped, 0, '', 27, 0, 0)
+
+    -- Use pants (component id 4) from mpHeist DLC collection ("female_heist"), local index 9 and texture number 3.
+    -- Same as SetPedComponentVariation(ped, 4, 41, 3, 0)
+    SetPedCollectionComponentVariation(ped, 4, 'female_heist', 9, 3, 0)
+
+    -- Use hat (anchor point 0) from mpBiker DLC collection ("mp_f_bikerdlc_01"), local index 0 and texture number 0.
+    -- Same as SetPedPropIndex(ped, 0, 82, 0, 0)
+    SetPedCollectionPropIndex(ped, 0, 'mp_f_bikerdlc_01', 0, 0, false)
+end
+
+function testInvalidComponentVariation(ped)
+    -- Attempt to set shirt (component id 11) from mpBeach DLC collection ("female_freemode_beach") but invalid (out of bounds) local index 999999.
+    -- The component drawable variation will not be set since the variation is invalid.
+    SetPedCollectionComponentVariation(ped, 11, 'female_freemode_beach', 999999, 0, 0)
+
+    -- Confirm that previously requested drawable variation is indeed invalid.
+    -- Same as IsPedComponentVariationValid(ped, 11, 999999 + 16, 0, 0)
+    -- +16 because there are 16 drawable variations in the base game collection that go before the mpBeach DLC collection.
+    if not IsPedCollectionComponentVariationValid(ped, 11, 'female_freemode_beach', 999999, 0, 0) then
+        print("Invalid component drawable variation was requested.")
+    end
+end
+
+RegisterCommand('SetPlayerPedLook', function(source)
+    local playerPed = PlayerPedId()
+    setLook(playerPed)
+    testInvalidComponentVariation(playerPed)
+end, true)
+```
+
+Print information about drawable variations that are set for the ped:
+
+```lua
+function printPedLookInfo(ped, componentId)
+    print(string.format("For component id %d, the following drawable is used:", componentId))
+
+    local collectionName = GetPedDrawableVariationCollectionName(ped, componentId)
+    local collectionLocalIndex = GetPedDrawableVariationCollectionLocalIndex(ped, componentId)
+
+    print(string.format("   Collection name: \"%s\"", collectionName))
+    print(string.format("   Local drawable index: %d", collectionLocalIndex))
+
+    -- Will get the same result as if we called GetPedDrawableVariation(ped, componentId)
+    local globalDrawableIndex = GetPedDrawableGlobalIndexFromCollection(ped, componentId, collectionName, collectionLocalIndex)
+
+    print(string.format("   Which corresponds to global drawable index: %d", globalDrawableIndex))
+end
+
+RegisterCommand('PrintPlayerPantsInfo', function(source)
+    local playerPed = PlayerPedId()
+    -- Print info about drawable variation that is set as pants (component id 4).
+    printPedLookInfo(playerPed, 4)
+end, true)
+```

--- a/content/docs/scripting-manual/using-new-game-features/collection-based-natives.md
+++ b/content/docs/scripting-manual/using-new-game-features/collection-based-natives.md
@@ -65,11 +65,11 @@ E.g.:
 </tbody>
 </table>
 
-#### Where collection name is set
-
 The first collection corresponds to the base game (without any DLCs). After the base game collection follow collection that correspond to official DLCs. Custom collections are added to the end.
 
 After TU is released and new official DLC collection is added - all custom collections are shifted. So, the global indexes that correspond to custom collections shift and must be updated on every TU. While the indexes that are relative to the beginning of a collection will remain stable after TU.
+
+#### Where collection name is set
 
 The base game name collection is an empty string. Names of other collections are set by `<CPedVariationInfo name="...">` tag of the corresponding `.ymt` file. E.g. see `Grand Theft Auto V\update\x64\dlcpacks\mp2024_01\dlc.rpf\x64\models\cdimages\mp2024_01_female.rpf\mp_f_freemode_01_mp_f_2024_01.ymt` base game file.
 

--- a/content/docs/scripting-manual/using-new-game-features/collection-based-natives.md
+++ b/content/docs/scripting-manual/using-new-game-features/collection-based-natives.md
@@ -19,18 +19,19 @@ You can think of collections in Ped as list of buckets placed one after another.
 
 E.g.:
 
-<table><tbody>
+<table class="collections-indices-example"><tbody>
   <tr>
     <td></td>
     <td colspan="9">Official GTAV collections</td>
-    <td colspan="3">Custom collections</td>
+    <td colspan="5">Custom collections</td>
   </tr>
   <tr>
     <td>Collection names</td>
     <td colspan="2">""</td>
     <td colspan="4">"feemale_freemode_beach"</td>
     <td colspan="3">"feemale_xmas"</td>
-    <td colspan="3">"custom_collection"</td>
+    <td colspan="3">"custom_collection_1"</td>
+    <td colspan="2">"custom_collection_2"</td>
   </tr>
   <tr>
     <td>Local indexes</td>
@@ -46,6 +47,8 @@ E.g.:
     <td>0</td>
     <td>1</td>
     <td>2</td>
+    <td>0</td>
+    <td>1</td>
   </tr>
   <tr>
     <td>Global indexes</td>
@@ -61,9 +64,21 @@ E.g.:
     <td>9</td>
     <td>10</td>
     <td>11</td>
+    <td>12</td>
+    <td>13</td>
   </tr>
 </tbody>
 </table>
+
+<style>
+.collections-indices-example td {
+    border: 0.5px solid grey;
+}
+
+.collections-indices-example td:not(:first-child) {
+    text-align: center !important;
+}
+</style>
 
 The first collection corresponds to the base game (without any DLCs). After the base game collection follow collection that correspond to official DLCs. Custom collections are added to the end.
 

--- a/content/docs/scripting-manual/using-new-game-features/collection-based-natives.md
+++ b/content/docs/scripting-manual/using-new-game-features/collection-based-natives.md
@@ -82,32 +82,32 @@ There are three groups of new natives:
 
 #### General info natives
 
-- [GET_PED_COLLECTIONS_COUNT](https://docs.fivem.net/natives/?_0x45946359) - get total number of collections available for Ped
-- [GET_PED_COLLECTION_NAME](https://docs.fivem.net/natives/?_0xFED5D83A) - get collection name by collection number
+- {{% native_link "GET_PED_COLLECTIONS_COUNT" %}} - get total number of collections available for Ped
+- {{% native_link "GET_PED_COLLECTION_NAME" %}} - get collection name by collection number
 
 #### Conversion between global and local indexing
 
-- [GET_PED_COLLECTION_NAME_FROM_DRAWABLE](https://docs.fivem.net/natives/?_0xD6BBA48B), [GET_PED_COLLECTION_LOCAL_INDEX_FROM_DRAWABLE](https://docs.fivem.net/natives/?_0x94EB1FE4) - get collection name and local index from global drawable index
-- [GET_PED_COLLECTION_NAME_FROM_PROP](https://docs.fivem.net/natives/?_0x8ED0C17), [GET_PED_COLLECTION_LOCAL_INDEX_FROM_PROP](https://docs.fivem.net/natives/?_0xFBDB885F) - get collection name and local index from global prop index
-- [GET_PED_DRAWABLE_GLOBAL_INDEX_FROM_COLLECTION](https://docs.fivem.net/natives/?_0x280F1FC3) - get global drawable index from collection name and local index
-- [GET_PED_PROP_GLOBAL_INDEX_FROM_COLLECTION](https://docs.fivem.net/natives/?_0x2CB45CDC) - get global prop index from collection name and local index
+- {{% native_link "GET_PED_COLLECTION_NAME_FROM_DRAWABLE" %}}, {{% native_link "GET_PED_COLLECTION_LOCAL_INDEX_FROM_DRAWABLE" %}} - get collection name and local index from global drawable index
+- {{% native_link "GET_PED_COLLECTION_NAME_FROM_PROP" %}}, {{% native_link "GET_PED_COLLECTION_LOCAL_INDEX_FROM_PROP" %}} - get collection name and local index from global prop index
+- {{% native_link "GET_PED_DRAWABLE_GLOBAL_INDEX_FROM_COLLECTION" %}} - get global drawable index from collection name and local index
+- {{% native_link "GET_PED_PROP_GLOBAL_INDEX_FROM_COLLECTION" %}} - get global prop index from collection name and local index
 
 #### Analogues to existing natives
 
 | Old (global index based) native | New (collection-based) native |
 | ---------- | ---------- |
-| [SET_PED_COMPONENT_VARIATION](https://docs.fivem.net/natives/?_0x262B14F48D29DE80) | [SET_PED_COLLECTION_COMPONENT_VARIATION](https://docs.fivem.net/natives/?_0x88711BBA) |
-| [SET_PED_PROP_INDEX](https://docs.fivem.net/natives/?_0x93376B65A266EB5F) | [SET_PED_COLLECTION_PROP_INDEX](https://docs.fivem.net/natives/?_0x75240BCB) |
-| [SET_PED_PRELOAD_VARIATION_DATA](https://docs.fivem.net/natives/?_0x39D55A620FCB6A3A) | [SET_PED_COLLECTION_PRELOAD_VARIATION_DATA](https://docs.fivem.net/natives/?_0x3EC75558) |
-| [SET_PED_PRELOAD_PROP_DATA](https://docs.fivem.net/natives/?_0x2B16A3BFF1FBCE49) | [SET_PED_COLLECTION_PRELOAD_PROP_DATA](https://docs.fivem.net/natives/?_0x14B5BBE0) |
-| [GET_NUMBER_OF_PED_DRAWABLE_VARIATIONS](https://docs.fivem.net/natives/?_0x27561561732A7842) | [GET_NUMBER_OF_PED_COLLECTION_DRAWABLE_VARIATIONS](https://docs.fivem.net/natives/?_0x310D0271) |
-| [GET_NUMBER_OF_PED_PROP_DRAWABLE_VARIATIONS](https://docs.fivem.net/natives/?_0x5FAF9754E789FB47) | [GET_NUMBER_OF_PED_COLLECTION_PROP_DRAWABLE_VARIATIONS](https://docs.fivem.net/natives/?_0x3B6A13E1) |
-| [GET_NUMBER_OF_PED_TEXTURE_VARIATIONS](https://docs.fivem.net/natives/?_0x8F7156A3142A6BAD) | [GET_NUMBER_OF_PED_COLLECTION_TEXTURE_VARIATIONS](https://docs.fivem.net/natives/?_0xD2C15D7) |
-| [GET_NUMBER_OF_PED_PROP_TEXTURE_VARIATIONS](https://docs.fivem.net/natives/?_0xA6E7F1CEB523E171) | [GET_NUMBER_OF_PED_COLLECTION_PROP_TEXTURE_VARIATIONS](https://docs.fivem.net/natives/?_0x75CAF9CC) |
-| [IS_PED_COMPONENT_VARIATION_VALID](https://docs.fivem.net/natives/?_0xE825F6B6CEA7671D) | [IS_PED_COLLECTION_COMPONENT_VARIATION_VALID](https://docs.fivem.net/natives/?_0xCA63A52A) |
-| [IS_PED_COMPONENT_VARIATION_GEN9_EXCLUSIVE](https://docs.fivem.net/natives/?_0xC767B581) | [IS_PED_COLLECTION_COMPONENT_VARIATION_GEN9_EXCLUSIVE](https://docs.fivem.net/natives/?_0x33B2AFA2) |
-| [GET_PED_DRAWABLE_VARIATION](https://docs.fivem.net/natives/?_0x67F3780DD425D4FC) | [GET_PED_DRAWABLE_VARIATION_COLLECTION_LOCAL_INDEX](https://docs.fivem.net/natives/?_0x9970386F) |
-| [GET_PED_DRAWABLE_VARIATION](https://docs.fivem.net/natives/?_0x67F3780DD425D4FC) | [GET_PED_DRAWABLE_VARIATION_COLLECTION_NAME](https://docs.fivem.net/natives/?_0xBCE0AB63) |
+| {{% native_link "SET_PED_COMPONENT_VARIATION" %}} | {{% native_link "SET_PED_COLLECTION_COMPONENT_VARIATION" %}} |
+| {{% native_link "SET_PED_PROP_INDEX" %}} | {{% native_link "SET_PED_COLLECTION_PROP_INDEX" %}} |
+| {{% native_link "SET_PED_PRELOAD_VARIATION_DATA" %}} | {{% native_link "SET_PED_COLLECTION_PRELOAD_VARIATION_DATA" %}} |
+| {{% native_link "SET_PED_PRELOAD_PROP_DATA" %}} | {{% native_link "SET_PED_COLLECTION_PRELOAD_PROP_DATA" %}} |
+| {{% native_link "GET_NUMBER_OF_PED_DRAWABLE_VARIATIONS" %}} | {{% native_link "GET_NUMBER_OF_PED_COLLECTION_DRAWABLE_VARIATIONS" %}} |
+| {{% native_link "GET_NUMBER_OF_PED_PROP_DRAWABLE_VARIATIONS" %}} | {{% native_link "GET_NUMBER_OF_PED_COLLECTION_PROP_DRAWABLE_VARIATIONS" %}} |
+| {{% native_link "GET_NUMBER_OF_PED_TEXTURE_VARIATIONS" %}} | {{% native_link "GET_NUMBER_OF_PED_COLLECTION_TEXTURE_VARIATIONS" %}} |
+| {{% native_link "GET_NUMBER_OF_PED_PROP_TEXTURE_VARIATIONS" %}} | {{% native_link "GET_NUMBER_OF_PED_COLLECTION_PROP_TEXTURE_VARIATIONS" %}} |
+| {{% native_link "IS_PED_COMPONENT_VARIATION_VALID" %}} | {{% native_link "IS_PED_COLLECTION_COMPONENT_VARIATION_VALID" %}} |
+| {{% native_link "IS_PED_COMPONENT_VARIATION_GEN9_EXCLUSIVE" %}} | {{% native_link "IS_PED_COLLECTION_COMPONENT_VARIATION_GEN9_EXCLUSIVE" %}} |
+| {{% native_link "GET_PED_DRAWABLE_VARIATION" %}} | {{% native_link "GET_PED_DRAWABLE_VARIATION_COLLECTION_LOCAL_INDEX" %}} |
+| {{% native_link "GET_PED_DRAWABLE_VARIATION" %}} | {{% native_link "GET_PED_DRAWABLE_VARIATION_COLLECTION_NAME" %}} |
 
 ### Examples
 

--- a/content/docs/scripting-manual/using-new-game-features/collection-based-natives.md
+++ b/content/docs/scripting-manual/using-new-game-features/collection-based-natives.md
@@ -3,11 +3,11 @@ title: Work with drawable components and props using collections
 weight: 421
 ---
 
-Inside the GTA5 Ped drawable components and props are stored in named groups called collections. However, collections were previously unavailable for FiveM users. The drawable components and props were indexed through global index. On every TU (Title Update) the global index of custom drawable components and props would change (see below for more details on why it happens). This complicates migration to the latest game build.
+Inside the GTAV Ped drawable components and props are stored in named groups called collections. However, collections were previously unavailable for FiveM users. The drawable components and props were indexed through global index. On every TU (Title Update) the global index of custom drawable components and props would change (see below for more details on why it happens). This complicates migration to the latest game build.
 
 The new set of natives allows accessing drawable components and props through collections. The collection-based indexes remain stable after TUs. **So using these natives will simplify all future TU updates for a server.**
 
-    Note: The new natives are currently available for GTA5 and on client side only.
+    Note: The new natives are currently available for GTAV and on client side only.
 
 ### How drawable components and props indexing works
 
@@ -22,7 +22,7 @@ E.g.:
 <table><tbody>
   <tr>
     <td></td>
-    <td colspan="9">Official GTA5 collections</td>
+    <td colspan="9">Official GTAV collections</td>
     <td colspan="3">Custom collections</td>
   </tr>
   <tr>

--- a/content/docs/scripting-manual/using-new-game-features/fuel-consumption.md
+++ b/content/docs/scripting-manual/using-new-game-features/fuel-consumption.md
@@ -3,7 +3,7 @@ title: Fuel consumption
 weight: 421
 ---
 
-By default in GTA5 and FiveM vehicles do not consume fuel. This feature allows to turn the fuel consumption on and customize it for your needs.
+By default in GTAV and FiveM vehicles do not consume fuel. This feature allows to turn the fuel consumption on and customize it for your needs.
 
 ### Turn on/off
 

--- a/content/docs/scripting-manual/using-new-game-features/fuel-consumption.md
+++ b/content/docs/scripting-manual/using-new-game-features/fuel-consumption.md
@@ -7,7 +7,7 @@ By default in GTA5 and FiveM vehicles do not consume fuel. This feature allows t
 
 ### Turn on/off
 
-To set/check the fuel consumption use [`SET_FUEL_CONSUMPTION_STATE`](https://docs.fivem.net/natives/?_0x81DAD03E)/[`GET_FUEL_CONSUMPTION_STATE`](https://docs.fivem.net/natives/?_0xC66CD90C) natives. Set true to turn it on, false - to turn it off.
+To set/check the fuel consumption use {{% native_link "SET_FUEL_CONSUMPTION_STATE" %}}/{{% native_link "GET_FUEL_CONSUMPTION_STATE" %}} natives. Set true to turn it on, false - to turn it off.
 
 ### How it works
 
@@ -27,19 +27,19 @@ By default, 65 liter gas tank car with average fuel consumption can stay **idle 
 
 #### Customize consumption speed
 
-To customize/check global (across all vehicles) fuel consumption rate (`global_fuel_consumption_rate_multiplier` in the formula above) use [`SET_FUEL_CONSUMPTION_RATE_MULTIPLIER`](https://docs.fivem.net/natives/?_0x845F3E5C)/[`GET_FUEL_CONSUMPTION_RATE_MULTIPLIER`](https://docs.fivem.net/natives/?_0x5550BF9F) natives. By default it is set to 1. If set to negative - 0 will be used instead.
+To customize/check global (across all vehicles) fuel consumption rate (`global_fuel_consumption_rate_multiplier` in the formula above) use {{% native_link "SET_FUEL_CONSUMPTION_RATE_MULTIPLIER" %}}/{{% native_link "GET_FUEL_CONSUMPTION_RATE_MULTIPLIER" %}} natives. By default it is set to 1. If set to negative - 0 will be used instead.
 
-To customize fuel consumption per vehicle (`vehicle_fuel_consumption_rate_multiplier` in the formula above) use [`SET_HANDLING_FLOAT`](https://docs.fivem.net/natives/?_0x90DD01C) (for all vehicles with given class) or [`SET_VEHICLE_HANDLING_FLOAT`](https://docs.fivem.net/natives/?_0x488C86D2) (for a specific vehicle) native with `fieldName` equal to `fPetrolConsumptionRate`. By default it is set to 0.5 for all vehicles.
+To customize fuel consumption per vehicle (`vehicle_fuel_consumption_rate_multiplier` in the formula above) use {{% native_link "SET_HANDLING_FLOAT" %}} (for all vehicles with given class) or {{% native_link "SET_VEHICLE_HANDLING_FLOAT" %}} (for a specific vehicle) native with `fieldName` equal to `fPetrolConsumptionRate`. By default it is set to 0.5 for all vehicles.
 
 You can also use [CodeWalker](https://github.com/dexyfex/CodeWalker) tool or similar to edit vehicle `handling.meta` file and set `fPetrolConsumptionRate` value to `HandlingData`. If not set it results to the default value of 0.5.
 
 #### Petrol tank volume and current fuel level
 
-To customize petrol tank volume use [`SET_HANDLING_FLOAT`](https://docs.fivem.net/natives/?_0x90DD01C)/[`SET_VEHICLE_HANDLING_FLOAT`](https://docs.fivem.net/natives/?_0x488C86D2) natives with `fieldName` equal to `fPetrolTankVolume`.
+To customize petrol tank volume use {{% native_link "SET_HANDLING_FLOAT" %}}/{{% native_link "SET_VEHICLE_HANDLING_FLOAT" %}} natives with `fieldName` equal to `fPetrolTankVolume`.
 
 You can also use [CodeWalker](https://github.com/dexyfex/CodeWalker) tool or similar to edit vehicle `handling.meta` file and set `fPetrolTankVolume` value to `HandlingData`.
 
-To update/check fuel level in a vehicle use [`GET_VEHICLE_FUEL_LEVEL`](https://docs.fivem.net/natives/?_0x5F739BB8)/[`SET_VEHICLE_FUEL_LEVEL`](https://docs.fivem.net/natives/?_0xBA970511) natives.
+To update/check fuel level in a vehicle use {{% native_link "GET_VEHICLE_FUEL_LEVEL" %}}/{{% native_link "SET_VEHICLE_FUEL_LEVEL" %}} natives.
 
 #### Vehicles without fuel consumption
 
@@ -49,7 +49,7 @@ Fuel is not consumed for the following vehicles:
 - Bicycles. I.e. vehicles with vehicle type equal to 12.
 - Vehicles with infinite fuel. I.e. vehicles with petrol tank volume equal to 0. By default it's only bicycles.
 
-To check if vehicle will consume fuel when player is inside (i.e. petrol tank volume above 0 and not a bicycle) use [`DOES_VEHICLE_USE_FUEL`](https://docs.fivem.net/natives/?_0xEF30A696) native.
+To check if vehicle will consume fuel when player is inside (i.e. petrol tank volume above 0 and not a bicycle) use {{% native_link "DOES_VEHICLE_USE_FUEL" %}} native.
 
 ### Gas stations
 


### PR DESCRIPTION
The natives were added in
https://github.com/citizenfx/fivem/commit/7dad6da713fc5c522f4c77d83803be6744f4b14f

NOTE: references to natives may be unavailable until the commit above passes canary and gets to production.