### PR TITLE
feat(loading-screens): document events

### DIFF
--- a/content/docs/scripting-manual/nui-development/loading-screens/_index.md
+++ b/content/docs/scripting-manual/nui-development/loading-screens/_index.md
@@ -74,4 +74,37 @@ When doing so, the following natives become available once scripts start (after 
 This can be used to, say, add a custom fade-out effect from the loading screen to an in-game view, or integrate NUI events
 with early-game spawn selection UI.
 
+## Events
+The loading screen will receive data about various events through the `message` event.
+You can handle these events by setting `window.onmessage` or by using `window.addEventListener` with `'message'` as the first argument, and checking the `eventName` value inside the event's `data` field.
+
+### Example
+```html
+<!-- loading screen bar -->
+<progress id="loading-bar" value="0" max="1"></progress>
+
+<script type="text/javascript">
+window.addEventListener('message', (event) => {
+    // ensure that we are handling the loadProgress event
+    if (event.data.eventName !== 'loadProgress') return;
+
+    // use the event's data to fill up the loading bar
+    document.getElementById('loading-bar').value = event.data.loadFraction;
+});
+</script>
+```
+
+### Event List
+- [loadProgress](./loadProgress)
+- [onLogLine](./onLogLine)
+- [startDataFileEntries](./startDataFileEntries)
+- [onDataFileEntry](./onDataFileEntry)
+- [performMapLoadFunction](./performMapLoadFunction)
+- [endDataFileEntries](./endDataFileEntries)
+- [startInitFunction](./startInitFunction)
+- [startInitFunctionOrder](./startInitFunctionOrder)
+- [initFunctionInvoking](./initFunctionInvoking)
+- [initFunctionInvoked](./initFunctionInvoked)
+- [endInitFunction](./endInitFunction)
+
 [resource-manifest]: /docs/scripting-reference/resource-manifest/resource-manifest

--- a/content/docs/scripting-manual/nui-development/loading-screens/endDataFileEntries.md
+++ b/content/docs/scripting-manual/nui-development/loading-screens/endDataFileEntries.md
@@ -1,0 +1,20 @@
+---
+title: endDataFileEntries
+toc_hide: true
+---
+
+Triggered when data file entries have ended, after the [startDataFileEntries](./startDataFileEntries) event
+and several [onDataFileEntry](./onDataFileEntry) events.
+
+Event Data
+----------
+
+This is the `data` provided to the message event:
+
+```ts
+interface EventData {
+    eventName: 'endDataFileEntries',
+}
+```
+
+- **eventName**: The event name.

--- a/content/docs/scripting-manual/nui-development/loading-screens/endInitFunction.md
+++ b/content/docs/scripting-manual/nui-development/loading-screens/endInitFunction.md
@@ -1,0 +1,21 @@
+---
+title: endInitFunction
+toc_hide: true
+---
+
+Triggered when init functions completed invoking, finalizing the [startInitFunction](./startInitFunction) event process.
+
+Event Data
+----------
+
+This is the `data` provided to the message event:
+
+```ts
+interface EventData {
+    eventName: 'endInitFunction',
+    type: string,
+}
+```
+
+- **eventName**: The event name.
+- **type**: The type of init functions that finished invoking.

--- a/content/docs/scripting-manual/nui-development/loading-screens/initFunctionInvoked.md
+++ b/content/docs/scripting-manual/nui-development/loading-screens/initFunctionInvoked.md
@@ -1,0 +1,23 @@
+---
+title: initFunctionInvoked
+toc_hide: true
+---
+
+Triggered after an init function was invoked, after [initFunctionInvoking](./initFunctionInvoking).
+
+Event Data
+----------
+
+This is the `data` provided to the message event:
+
+```ts
+interface EventData {
+    eventName: 'initFunctionInvoked',
+    type: string,
+    name: string,
+}
+```
+
+- **eventName**: The event name.
+- **type**: The type of init function that was invoked.
+- **name**: The name of the init function.

--- a/content/docs/scripting-manual/nui-development/loading-screens/initFunctionInvoking.md
+++ b/content/docs/scripting-manual/nui-development/loading-screens/initFunctionInvoking.md
@@ -1,0 +1,28 @@
+---
+title: initFunctionInvoking
+toc_hide: true
+---
+
+Triggered when an init function is being invoked, as a result of [startInitFunctionOrder](./startInitFunctionOrder).
+
+Several [onDataFileEntry](./onDataFileEntry) may be triggered after this.
+After the init function finishes invoking, [initFunctionInvoked](./initFunctionInvoked) will be triggered.
+
+Event Data
+----------
+
+This is the `data` provided to the message event:
+
+```ts
+interface EventData {
+    eventName: 'initFunctionInvoking',
+    type: string,
+    name: string,
+    idx: number,
+}
+```
+
+- **eventName**: The event name.
+- **type**: The type of init function being invoked.
+- **name**: The name of the init function.
+- **idx**: The index of the init function.

--- a/content/docs/scripting-manual/nui-development/loading-screens/loadProgress.md
+++ b/content/docs/scripting-manual/nui-development/loading-screens/loadProgress.md
@@ -1,0 +1,39 @@
+---
+title: loadProgress
+toc_hide: true
+---
+
+Triggered when the loading progress percentage is updated.
+
+Event Data
+----------
+
+This is the `data` provided to the message event:
+
+```ts
+interface EventData {
+    eventName: 'loadProgress',
+    loadFraction: number,
+}
+```
+
+- **eventName**: The event name.
+- **loadFraction**: The total loading percentage as a fraction from 0 to 1 (inclusive).
+
+Examples
+--------
+
+```html
+<!-- loading screen bar -->
+<progress id="loading-bar" value="0" max="1"></progress>
+
+<script type="text/javascript">
+window.addEventListener('message', (event) => {
+    // ensure that we are handling the loadProgress event
+    if (event.data.eventName !== 'loadProgress') return;
+
+    // use the event's data to fill up the loading bar
+    document.getElementById('loading-bar').value = event.data.loadFraction;
+});
+</script>
+```

--- a/content/docs/scripting-manual/nui-development/loading-screens/onDataFileEntry.md
+++ b/content/docs/scripting-manual/nui-development/loading-screens/onDataFileEntry.md
@@ -1,0 +1,26 @@
+---
+title: onDataFileEntry
+toc_hide: true
+---
+
+Triggered when a data file entry occurred, as either a result of
+[startDataFileEntries](./startDataFileEntries) or [initFunctionInvoking](./initFunctionInvoking).
+
+Event Data
+----------
+
+This is the `data` provided to the message event:
+
+```ts
+interface EventData {
+    eventName: 'onDataFileEntry',
+    name: string,
+    type: number,
+    isNew: boolean,
+}
+```
+
+- **eventName**: The event name.
+- **name**: The name of the data file entry.
+- **type**: The type of the data file entry.
+- **isNew**: Whether this data file entry is new.

--- a/content/docs/scripting-manual/nui-development/loading-screens/onLogLine.md
+++ b/content/docs/scripting-manual/nui-development/loading-screens/onLogLine.md
@@ -1,0 +1,38 @@
+---
+title: onLogLine
+toc_hide: true
+---
+
+Triggered to log the initialization of resources.
+
+Event Data
+----------
+
+This is the `data` provided to the message event:
+
+```ts
+interface EventData {
+    eventName: 'onLogLine',
+    message: string,
+}
+```
+
+- **eventName**: The event name.
+- **message**: The log message.
+
+Examples
+--------
+```html
+<!-- loading screen bar -->
+<p id="log"></p>
+
+<script type="text/javascript">
+window.addEventListener('message', (event) => {
+    // ensure that we are handling the onLogLine event
+    if (event.data.eventName !== 'onLogLine') return;
+
+    // use the event's data to fill up the log line
+    document.getElementById('log').innerText = event.data.message;
+});
+</script>
+```

--- a/content/docs/scripting-manual/nui-development/loading-screens/performMapLoadFunction.md
+++ b/content/docs/scripting-manual/nui-development/loading-screens/performMapLoadFunction.md
@@ -1,0 +1,21 @@
+---
+title: performMapLoadFunction
+toc_hide: true
+---
+
+Triggered when a map load function was called, either by itself or as a result of [onDataFileEntry](./onDataFileEntry).
+
+Event Data
+----------
+
+This is the `data` provided to the message event:
+
+```ts
+interface EventData {
+    eventName: 'performMapLoadFunction',
+    idx: number,
+}
+```
+
+- **eventName**: The event name.
+- **idx**: The map index.

--- a/content/docs/scripting-manual/nui-development/loading-screens/startDataFileEntries.md
+++ b/content/docs/scripting-manual/nui-development/loading-screens/startDataFileEntries.md
@@ -1,0 +1,24 @@
+---
+title: startDataFileEntries
+toc_hide: true
+---
+
+Triggered when data file entries are incoming.
+
+Several [onDataFileEntry](./onDataFileEntry) events will be triggered after this,
+and a [endDataFileEntries](./endDataFileEntries) event will be triggered after the given data files entries are done.
+
+Event Data
+----------
+
+This is the `data` provided to the message event:
+
+```ts
+interface EventData {
+    eventName: 'startDataFileEntries',
+    count: number,
+}
+```
+
+- **eventName**: The event name.
+- **count**: The amount of data file entries incoming.

--- a/content/docs/scripting-manual/nui-development/loading-screens/startInitFunction.md
+++ b/content/docs/scripting-manual/nui-development/loading-screens/startInitFunction.md
@@ -1,0 +1,26 @@
+---
+title: startInitFunction
+toc_hide: true
+---
+
+Triggered when init functions are about to be invoked.
+
+[startInitFunctionOrder](./startInitFunctionOrder) will be triggered after this with additional info,
+in turn triggering multiple [initFunctionInvoking](./initFunctionInvoking) and in turn [initFunctionInvoked](./initFunctionInvoked) triggers.
+After the init functions were invoked, [startInitFunctionOrder](./startInitFunctionOrder) will be triggered again with additional functions,
+or [endInitFunction](./endInitFunction) will be triggered, finalizing the process.
+
+Event Data
+----------
+
+This is the `data` provided to the message event:
+
+```ts
+interface EventData {
+    eventName: 'startInitFunction',
+    type: string,
+}
+```
+
+- **eventName**: The event name.
+- **type**: The type of init functions to be invoked.

--- a/content/docs/scripting-manual/nui-development/loading-screens/startInitFunctionOrder.md
+++ b/content/docs/scripting-manual/nui-development/loading-screens/startInitFunctionOrder.md
@@ -1,0 +1,30 @@
+---
+title: startInitFunctionOrder
+toc_hide: true
+---
+
+Triggered after [startInitFunction](./startInitFunction), with additional data.
+May be triggered multiple times under the same init function type, but with a different `order` value.
+
+Several [initFunctionInvoking](./initFunctionInvoking) and in turn [initFunctionInvoked](./initFunctionInvoked) events will be triggered after this.
+After the init functions were invoked, **startInitFunctionOrder** may be triggered again with additional functions,
+or [endInitFunction](./endInitFunction) will be triggered, finalizing the process.
+
+Event Data
+----------
+
+This is the `data` provided to the message event:
+
+```ts
+interface EventData {
+    eventName: 'startInitFunctionOrder',
+    type: string,
+    order: number,
+    count: number,
+}
+```
+
+- **eventName**: The event name.
+- **type**: The type of init functions to be invoked.
+- **order**: The order of the init functions to be invoked.
+- **count**: The amount of init function to be invoked.


### PR DESCRIPTION
Documents loading screen events as seen in [`LoadingScreens.cpp`](https://github.com/citizenfx/fivem/blob/56f6e3871fc376378e895a9c2d2232cc45c30e18/code/components/loading-screens-five/src/LoadingScreens.cpp), and how to use them (or at least some of them).
Not sure how correct this is since I don't have deep and extensive knowledge of the codebase.