### PR TITLE
Remove keymaster IP instructions

### DIFF
--- a/content/docs/server-manual/setting-up-a-server.md
+++ b/content/docs/server-manual/setting-up-a-server.md
@@ -12,8 +12,6 @@ Having trouble running your server? Check the [server issue FAQ][server-issues],
 ## Before you begin
 If you haven't done so yet, register a free license key on the [Cfx.re Keymaster](https://keymaster.fivem.net/).
 
-When asked for an IP, the IP should be the *public* IP on which you're going to *first* use the key. Afterwards, the key can be used for a single server instance on any IP.
-
 ## Available guides
 - [ZAP-Hosting setup guide][setting-up-a-server-zap]
 - [Ultimate easy setup guide (txAdmin)][setting-up-a-server-txadmin]


### PR DESCRIPTION
It is no longer required to put your IP adress when registering a new key, this PR matches these changes in the docs