### PR TITLE
Improved specifications for loadscreen

### DIFF
--- a/content/docs/scripting-manual/nui-development/loading-screens/_index.md
+++ b/content/docs/scripting-manual/nui-development/loading-screens/_index.md
@@ -36,6 +36,8 @@ event. This data will be passed to the loading screen in the `window.nuiHandover
 In addition to data specified by the server, a field named `serverAddress` is also added with the current IP/port used for
 the client->server connection.
 
+The handover function is only implemented inside the lua runtime environment.
+
 ### Example
 ```lua
 -- Server script


### PR DESCRIPTION
Currently the deferrals.handover method is only shown to work in a lua example however it isn't specified that it's only a feature in the lua runtime and not for example the JS runtime.