### PR TITLE
Correct broken URLs

### DIFF
--- a/content/docs/client-manual/citizenfx.md
+++ b/content/docs/client-manual/citizenfx.md
@@ -29,7 +29,7 @@ You can also add the following in this file:
 SavedBuildNumber=1604
 ```
 
-You can find the list of game builds [here](docs/server-manual/server-commands/#sv_enforcegamebuild-build).
+You can find the list of game builds [here](/docs/server-manual/server-commands/#sv_enforcegamebuild-build).
 
 This will launch FiveM directly into the specified build so you don't have to transition when connecting to servers on the specified build.
 

--- a/content/docs/client-manual/shortcut.md
+++ b/content/docs/client-manual/shortcut.md
@@ -55,7 +55,7 @@ Where `X` will represent the level you wish to have (0-2 available). This will l
 %localappdata%\FiveM\FiveM.exe -b1604
 ```
 
-Where `XXXX` will represent the build number you wish. You can find the list [here](docs/server-manual/server-commands/#sv_enforcegamebuild-build). This will launch FiveM app directly to the build asked. This is good if you play on a specific server to avoid the "build transition".
+Where `XXXX` will represent the build number you wish. You can find the list [here](/docs/server-manual/server-commands/#sv_enforcegamebuild-build). This will launch FiveM app directly to the build asked. This is good if you play on a specific server to avoid the "build transition".
 
 ---
 

--- a/content/docs/developers/server-security.md
+++ b/content/docs/developers/server-security.md
@@ -55,7 +55,7 @@ RegisterNetEvent("eventName", function(eventParam1, eventParam2)
 end)
 ```
 
-You can learn more [on this guide](docs/scripting-manual/working-with-events/listening-for-events/).
+You can learn more [on this guide](/docs/scripting-manual/working-with-events/listening-for-events/).
 
 ### Add Checks
 Even if you build a strong anti-cheat, adding checks on **server** events makes them more secure. This is a good practice, although it doesn't prevent everything. Below, we will share some good tips.
@@ -188,17 +188,17 @@ How many X's in a row do we need to see a player over the `timeout_sec` in order
 ```
 sv_authMaxVariance
 ```
-**Variance** is how likely the user's id will change for a given provider (i.e. 'steam', 'ip', or 'license'). You can learn about it [here](docs/server-manual/server-commands/#sv_authmaxvariance-newvalue).
+**Variance** is how likely the user's id will change for a given provider (i.e. 'steam', 'ip', or 'license'). You can learn about it [here](/docs/server-manual/server-commands/#sv_authmaxvariance-newvalue).
 
 ```
 sv_authMinTrust
 ```
-**Trust** is how unlikely it is for the user's identity to be spoofed by a malicious client. You can learn about it [here](docs/server-manual/server-commands/#sv_authmintrust-newvalue).
+**Trust** is how unlikely it is for the user's identity to be spoofed by a malicious client. You can learn about it [here](/docs/server-manual/server-commands/#sv_authmintrust-newvalue).
 
 ```
 sv_filterRequestControl
 ```
-A console variable used to block `REQUEST_CONTROL_EVENT` routing based on a configurable policy. You can learn about the list [here](docs/server-manual/server-commands/#sv_filterrequestcontrol-mode).
+A console variable used to block `REQUEST_CONTROL_EVENT` routing based on a configurable policy. You can learn about the list [here](/docs/server-manual/server-commands/#sv_filterrequestcontrol-mode).
 
 ### Results on Player
 Having those convars active will likely get the player kick with the following reason:


### PR DESCRIPTION
Correct broken URLs without preceding '/' which ultimately lead to a 404 page.