### PR TITLE
Fix more broken links and remove outdated info.

### DIFF
--- a/content/docs/contributing/how-you-can-help.md
+++ b/content/docs/contributing/how-you-can-help.md
@@ -14,7 +14,7 @@ Do you love the GTA universe and want to explore its details? You can make a big
 
 ## Improving Documentation
 
-Documentation is a continual work in progress, and we always welcome improvements. If you spot any areas for improvement, you can submit a pull request on our [docs repository][docs-rep], or simply click the "Improve this page" link at the bottom of any documentation page. You can also create a Github issue to suggest new pages. Any contribution is welcome!
+Documentation is a continual work in progress, and we always welcome improvements. If you spot any areas for improvement, you can submit a pull request on our [docs repository][docs-rep]. You can also create a [Github issue][docs-issues] to suggest new pages. Any contribution is welcome!
 
 ### Method signatures
 All text needs to be written in American English (AmE) style. Please note any variations in spelling, punctuation, or terminology compared to other English language variants.
@@ -22,3 +22,4 @@ All text needs to be written in American English (AmE) style. Please note any va
 [developer-docs]: /docs/developers
 [discord]: https://discord.gg/fivem
 [docs-rep]: https://github.com/citizenfx/fivem-docs
+[docs-issues]: https://github.com/citizenfx/fivem-docs/issues

--- a/content/docs/game-references/game-events.md
+++ b/content/docs/game-references/game-events.md
@@ -281,4 +281,4 @@ useful information to share, please [add it to this doc][contributing]. Any help
 | CEventWrithe                                       |             |
 
 [event-ref]: /docs/scripting-reference/events/list/gameEventTriggered
-[contributing]: /contributing
+[contributing]: /docs/contributing/how-you-can-help/#improving-documentation

--- a/content/docs/scripting-manual/introduction/about-native-functions.md
+++ b/content/docs/scripting-manual/introduction/about-native-functions.md
@@ -80,7 +80,7 @@ end, false)
 ```
 
 ### Create Your First Resource
-To learn how to create your first resource step-by-step, refer to the comprehensive guide in [this section](/content/docs/scripting-manual/introduction/creating-your-first-script.md). This guide will walk you through the process of setting up a new resource, writing your first script, and integrating it into your FiveM server.
+To learn how to create your first resource step-by-step, refer to the comprehensive guide in [this section](/docs/scripting-manual/introduction/creating-your-first-script). This guide will walk you through the process of setting up a new resource, writing your first script, and integrating it into your FiveM server.
 
 ### Commonly Used Native Functions
 Here are some commonly used native functions and their descriptions:


### PR DESCRIPTION
This PR addresses a broken link in the documentation repository and removes the mention of "Improve this page" within the "How you can help" section, which no longer exists. It also adds a link to the docs issues section.

This is all I have as of now, couldn't find any other broken links.