### PR TITLE
docs(resource-manifest): include oal information

### DIFF
--- a/content/docs/scripting-reference/resource-manifest/resource-manifest.md
+++ b/content/docs/scripting-reference/resource-manifest/resource-manifest.md
@@ -308,7 +308,7 @@ use_experimental_fxv2_oal "yes"
 ```
 
 {{% alert color="warning" %}}
-This feature is still experimental and also **requires** [Lua 5.4](#lua54) to be used.
+This feature is still experimental and **requires** [Lua 5.4](#lua54) to be used.
 {{% /alert %}}
 
 #### Vector unpacking

--- a/content/docs/scripting-reference/resource-manifest/resource-manifest.md
+++ b/content/docs/scripting-reference/resource-manifest/resource-manifest.md
@@ -299,6 +299,18 @@ Marks the current resource as a replacement for the specified resource. This mea
 provide 'mysql-async'
 ```
 
+### use_experimental_fxv2_oal
+
+This will enable the usage of OAL for Lua. This aims to correct return-types of natives and provide better performance via faster native calls.
+
+```lua
+use_experimental_fxv2_oal "yes"
+```
+
+{{% alert color="warning" %}}
+This feature is still experimental, it also **requires** Lua 5.4 to be used.
+{{% /alert %}}
+
 ### clr_disable_task_scheduler
 
 When present, disables the custom C# task scheduler on the server. This will increase compatibility with third-party libraries using the .NET TPL, but make it more likely you'll have to `await Delay(0);` to end up back on the main thread.

--- a/content/docs/scripting-reference/resource-manifest/resource-manifest.md
+++ b/content/docs/scripting-reference/resource-manifest/resource-manifest.md
@@ -301,15 +301,34 @@ provide 'mysql-async'
 
 ### use_experimental_fxv2_oal
 
-This will enable the usage of OAL for Lua. This aims to correct return-types of natives and provide better performance via faster native calls.
+This will enable the usage of OAL (One Argument List) for Lua. This aims to correct return-types of natives and provide better performance via faster native calls.
 
 ```lua
 use_experimental_fxv2_oal "yes"
 ```
 
 {{% alert color="warning" %}}
-This feature is still experimental, it also **requires** Lua 5.4 to be used.
+This feature is still experimental and also **requires** [Lua 5.4](#lua54) to be used.
 {{% /alert %}}
+
+#### Vector unpacking
+
+Vector unpacking is not a feature when using OAL, this means that you will have to explicitly unpack each coordinate into the native. Example below.
+
+```lua
+local coords = vector3(1, 2, 3)
+
+SetEntityCoords(ped, coords) -- would normally work, but NOT with OAL
+SetEntityCoords(ped, coords.x, coords.y, coords.z) -- works both with OAL, and without
+```
+
+#### Downsides
+
+Using OAL does have its downsides, if used incorrectly. Which is especially easy to do in more unexplored/unknown areas, such as RedM.
+
+More specifically, if a native is called with incorrect parameters. Such as unpacked vectors, `0` or `1` instead of `false` or `true`, and so on.
+
+Therefore, please ensure the types of the native parameters if you want to use OAL.
 
 ### clr_disable_task_scheduler
 

--- a/content/docs/scripting-reference/resource-manifest/resource-manifest.md
+++ b/content/docs/scripting-reference/resource-manifest/resource-manifest.md
@@ -324,11 +324,9 @@ SetEntityCoords(ped, coords.x, coords.y, coords.z) -- works both with OAL, and w
 
 #### Downsides
 
-Using OAL does have its downsides, if used incorrectly. Which is especially easy to do in more unexplored/unknown areas, such as RedM.
+OALs main downside is that it cannot be used if the parameter type is wrong, as internally it will be converted to whatever the underlying type is.
 
-More specifically, if a native is called with incorrect parameters. Such as unpacked vectors, `0` or `1` instead of `false` or `true`, and so on.
-
-Therefore, please ensure the types of the native parameters if you want to use OAL.
+This means that for natives that are undocumented or don't have the right types OAL will break in unexpected ways, or likely just not working at all.
 
 ### clr_disable_task_scheduler
 

--- a/content/docs/scripting-reference/resource-manifest/resource-manifest.md
+++ b/content/docs/scripting-reference/resource-manifest/resource-manifest.md
@@ -313,7 +313,7 @@ This feature is still experimental and **requires** [Lua 5.4](#lua54) to be used
 
 #### Vector unpacking
 
-Vector unpacking is not a feature when using OAL, this means that you will have to explicitly unpack each coordinate into the native. Example below.
+Vector unpacking does not work when using OAL, this means that you will have to manually unpack coordinates instead of providing the `vector3`.
 
 ```lua
 local coords = vector3(1, 2, 3)


### PR DESCRIPTION
Hello, I've noticed that there's genuinely no clear information on OAL in the documentation

I do understand that this might be an experimental feature, but a lot of people want to understand it and start to play around with it.
A good start would be to add it to the resource manifest docs, but with a disclaimer.