### PR TITLE
Remove ESX Framework Reference Due to ongoing Association with Unauthorized Services

### DIFF
--- a/content/docs/server-manual/frameworks.md
+++ b/content/docs/server-manual/frameworks.md
@@ -15,7 +15,6 @@ While each framework comes with its own documentation for setup, we recommend le
 If there's a framework you believe should be included in this list, please submit a request by creating an issue in the documentation [issues section](https://github.com/citizenfx/fivem-docs/issues).
 
 # Frameworks (Lua) (Alphabetical Order) 
-- [ESX](https://github.com/esx-framework/esx-legacy) ([Docs](https://documentation.esx-framework.org/legacy/installation))
 - [ND](https://github.com/ND-Framework/ND_Core) ([Docs](https://ndcore.dev/setup))
 - [QBCore](https://github.com/qbcore-framework/qb-core) ([Docs](https://docs.qbcore.org/qbcore-documentation/))
 - [Qbox](https://github.com/Qbox-project/qbx_core) ([Docs](https://docs.qbox.re/installation))


### PR DESCRIPTION
This pull request removes references to the ESX framework from the FiveM documentation. The decision to propose this change is based on the following concern:

#### Association with Unauthorized Game Service Providers (GSPs)
1. The ESX framework is prominently linked to a Game Service Provider (GSP) on its website, allowing server owners to set up ESX-based servers with a "one-click installer." While the GSP link was removed from the ESX documentation last month, it remains active on the official ESX website. This continued association will mislead users into inadvertently violating CFX.re and Rockstar policies.

2. The official ESX X (Twitter) account has previously acknowledged and promoted partnerships with a Game Service Provider (GSP). While these promotions may no longer be actively highlighted, their past public association with such entities raises concerns. These promotions remain visible, contributing to ongoing community perceptions of endorsement and potentially misleading server owners into using unauthorized services or engaging in questionable practices.

3. The footer of the official ESX website currently states "Powered by [GSP]," which indicates a direct endorsement or reliance on the Game Service Provider (GSP) in question. This explicit mention reinforces the perception of an ongoing partnership, even if prior documentation references have been removed.

References:

- GSP Mention on ESX Website: 
  https://www.esx-framework.org/
  <img width="622" src="https://github.com/user-attachments/assets/b5d80245-dafc-43cf-b8fb-3f40fed09871">
  <img width="622" src="https://github.com/user-attachments/assets/98f618fd-083c-47f1-981c-46a2261e6a40">
  <img width="293" src="https://github.com/user-attachments/assets/e62c2f65-bbcf-4103-bde1-52dc0210b062">
- X:
  https://x.com/esx_framework
  https://x.com/esx_framework/status/1634285085108195342
  <img width="427" src="https://github.com/user-attachments/assets/09cd5cba-0b6e-46f9-a7d3-918aca451ebd">
