### PR TITLE
fix: Make Scaleform boilerplate downloadable

### DIFF
--- a/content/docs/scripting-manual/using-scaleform/_index.md
+++ b/content/docs/scripting-manual/using-scaleform/_index.md
@@ -36,7 +36,7 @@ This variable serves as a kind of public API of the .gfx.
 It'd be pretty time consuming to explain in details how to bootstrap your first gfx thing, so instead please use the boilerplate:
 
 Related files:  
-[boilerplate.zip](/static/examples/using-scaleform/boilerplate.zip)
+[boilerplate.zip](https://github.com/citizenfx/fivem-docs/raw/refs/heads/master/static/examples/using-scaleform/boilerplate.zip)
 
 ### Loading
 


### PR DESCRIPTION
Fixes #506 
Unless an internal, fixes the access on static files