### PR TITLE
tweak(console-commands): remove 'net_maxPackets' as it no longer exists

### DIFF
--- a/content/docs/client-manual/console-commands.md
+++ b/content/docs/client-manual/console-commands.md
@@ -170,13 +170,6 @@ Allows you to load in TXDs and drawables via an graphical interface.
 
 Usage: `modelviewer <true|false>`
 
-### net_maxPackets
-A configuration flag to tell the client how many packets it should send at minimum per second.
-
-The default value is 50, minimum is 1 and maximum is 200 per second.
-
-Usage: `net_maxPackets <number_of_packets>`
-
 ### net_printOwner \<objectID>
 Prints the owner of a network object ID.
 


### PR DESCRIPTION
This PR removes the `net_maxPackets` command from the 'console commands' documentation.

When attempting to execute this command, an error message is displayed indicating that the command does not exist. After investigating the codebase, I could not find any trace of this command in the current version of the code.  