### PR TITLE
fix(game-refs/veh-models): Helicopters category not displayed in right menu

### DIFF
--- a/content/docs/game-references/vehicle-references/vehicle-models.md
+++ b/content/docs/game-references/vehicle-references/vehicle-models.md
@@ -5619,6 +5619,8 @@ weight: 760
         </div>
     </div>
 </div>
+
+## Helicopters
 <div class="category" id="helicopters">
     <h2>Helicopters</h2>
     <div class="vehicles">


### PR DESCRIPTION
The Helicotere category is not displayed in the menu on the right

![image](https://github.com/user-attachments/assets/6a96f36a-ac96-4437-8738-d2dc10dade19)

Just added space and markdown 