### PR TITLE
docs(server/commands): add Building pool increase

### DIFF
--- a/content/docs/server-manual/server-commands.md
+++ b/content/docs/server-manual/server-commands.md
@@ -444,6 +444,7 @@ Set of allowed pools and the maximum size increase per pool are set in `content.
 | Pool name  | FiveM max increase | RedM max increase |
 | ---------- | ------------------ | ----------------- |
 | AttachmentExtension | 430 | 430 |
+| Building | 20000 | - |
 | CDoorExtension (also known as MaxDoorExtensions) | - | 160 |
 | CLightEntity | - | 2000 |
 | CMoveObject | 75 | 100 |


### PR DESCRIPTION
Update server-commands documentation to add latest Building pool increase option in server cfg.

Reference: https://github.com/citizenfx/fivem/issues/2984#issuecomment-2674635143