### PR TITLE
tweak(server/scripting-reference): fix broken link

### DIFF
--- a/content/docs/scripting-reference/_index.md
+++ b/content/docs/scripting-reference/_index.md
@@ -16,7 +16,7 @@ We offer a variety of excellent tools to help you get started with your server. 
 
 - [Convars](/docs/scripting-reference/convars)
 - [OneSync](/docs/scripting-reference/onesync)
-- [State Bags](/docs/scripting-manual/networking/state-bags.md)
+- [State Bags](/docs/scripting-manual/networking/state-bags)
 - [Resource Manifest](/docs/scripting-reference/resource-manifest/resource-manifest)
 
 ### Develop Scripts


### PR DESCRIPTION
This commit removes the `.md` from the end of the URL, which caused the return to be a page not found.