### PR TITLE
fix 404 on CEF

### DIFF
--- a/content/docs/scripting-manual/nui-development/_index.md
+++ b/content/docs/scripting-manual/nui-development/_index.md
@@ -4,7 +4,7 @@ weight: 440
 ---
 
 **NUI** (short for 'new UI') is the HTML-based user interface functionality in the CitizenFX framework. Currently using
-the [Chromium Embedded Framework](cef), it offers an asynchronous, performant way of creating in-game UI using
+the [Chromium Embedded Framework](https://github.com/citizenfx/cef), it offers an asynchronous, performant way of creating in-game UI using
 web technologies (HTML/CSS/JS, including frameworks like React or Angular, and accelerated WebGL).
 
 - [Fullscreen NUI](/docs/scripting-manual/nui-development/full-screen-nui)


### PR DESCRIPTION
Currently, clicking the CEF button on https://docs.fivem.net/docs/scripting-manual/nui-development/ leads to a 404