### PR TITLE
Tweak: refresh pool and net docs

### DIFF
--- a/content/docs/scripting-manual/working-with-events/triggering-events.md
+++ b/content/docs/scripting-manual/working-with-events/triggering-events.md
@@ -24,7 +24,9 @@ emit("eventName", eventParam1, eventParam2);
 
 ### Triggering server events
 There are currently two different ways to trigger a server event from inside a **client** script.
-For smaller transactions the you should use `TriggerServerEvent`, while for larger transactions (which contain more data) `TriggerLatentServerEvent` would be more optimal.
+
+For smaller transactions you should use `TriggerServerEvent`, while for larger transactions (which contain more data, multiple KBs and above) `TriggerLatentServerEvent` would be more optimal.
+
 #### Example
 **Lua**
 ```lua
@@ -44,7 +46,7 @@ emitNet("eventName", eventParam1, eventParam2);
 #### Triggering latent server events
 Latent events should be used when needing to transfer a large amount of data from client -> server, as latent events **do not** block the entire network channel, unlike `TriggerServerEvent`. 
 
-Latent events take an extra paramater 'bps' which stands for 'bytes per second', this defines how fast it should send data to the server.
+Latent events take an extra paramater 'bps' which stands for 'bytes per second', this defines how fast it should send data to the server. If 'bps' is set to -1 or 0 - default bps of 25000 will be applied.
 
 **Lua**
 ```lua
@@ -100,7 +102,11 @@ Latent events should be used when needing to transfer a large amount of data fro
 
 This is important for timeout functionality, as sending a large amount of data blocks the network for the client, and if blocked for too long, will result in the client timing out. 
 
-Latent events take an extra paramater 'bps' which stands for 'bytes per second', this defines how fast it should send data to the client.
+Latent events take an extra paramater 'bps' which stands for 'bytes per second', this defines how fast it should send data to the client. If 'bps' is set to -1 or 0 - default bps of 25000 will be applied.
+
+'bps' applies to a single target. I.e. if `targetPlayer` is set to `-1` and event is sent to all connected users - the server will be effectively sending `bps * player_count` bytes every second.
+
+Note: setting `bps` to extremely large numbers (approximately `10 000 000` and above) may lead connectivity and performance issues when large objects are sent. Because the system will try to send everything at once.
 
 **Lua**
 ```lua

--- a/content/docs/server-manual/server-commands.md
+++ b/content/docs/server-manual/server-commands.md
@@ -451,22 +451,30 @@ Set of allowed pools and the maximum size increase per pool are set in `content.
 
 | Pool name  | FiveM max increase | RedM max increase |
 | ---------- | ------------------ | ----------------- |
+| AnimStore | 20480 | - |
 | AttachmentExtension | 430 | 430 |
 | Building | 20000 | - |
+| CAvoidanceComponent | - | 1300 |
 | CDoorExtension (also known as MaxDoorExtensions) | - | 160 |
 | CLightEntity | - | 2000 |
 | CMoveObject | 600 | 100 |
+| CompEntity | - | 50 |
 | CPropSetObjectExtension | - | 950 |
+| CWeaponComponentInfo | 2048 | - |
+| DrawableStore | - | 50000 |
 | EntityDescPool | 20480 | - |
+| fragInstGta | 2000 | - |
 | FragmentStore | 14000 | 4000 |
+| GrassBatch | - | 2000 |
 | InteriorProxy | 450 | 450 |
 | LightEntity | 1000 | - |
 | netGameEvent | 400 | 400 |
+| Object | 2000 | 2000 |
+| ObjectIntelligence | 512 | - |
 | OcclusionInteriorInfo | 20 | 10 |
 | OcclusionPathNode | 5000 | 1500 |
 | OcclusionPortalEntity | 750 | 140 |
 | OcclusionPortalInfo | 750 | 140 |
-| fragInstGta | 2000 | - |
 | PortalInst | 225 | 150 |
 | ScaleformStore | 200 | 100 |
 | StaticBounds | 5000 | 6500 |


### PR DESCRIPTION
This PR contains of two independent commits:
- Update pool size restrictions in accordance to the latest production state
- Clarify net event documentation, specifically the bps part of it