### PR TITLE
Zones in game references

### DIFF
--- a/content/docs/game-references/_index.md
+++ b/content/docs/game-references/_index.md
@@ -21,3 +21,4 @@ Reference lists and guides for game data are in this category.
 - [Pickup Hashes](/docs/game-references/pickup-hashes)
 - [Weapon models](/docs/game-references/weapon-models)
 - [Net Game Events](/docs/game-references/net-game-events)
+- [Zones](/docs/game-references/zones)

--- a/content/docs/game-references/zones.md
+++ b/content/docs/game-references/zones.md
@@ -1,0 +1,1333 @@
+---
+title: Zones
+weight: 740
+---
+
+A list of all zones in GTAV including their integer ID, string ID, short name used by natives and full name, based on `update\update.rpf\common\data\levels\gta5\popzone.ipl`. The column Zone Name ID is what is used by [GET_ZONE_FROM_NAME_ID](https://docs.fivem.net/natives/?_0x98CD1D2934B76CC1), while Zone Name is what is returned by [GET_NAME_OF_ZONE](https://docs.fivem.net/natives/?_0xCD90657D4C30E1CA).
+
+Zones
+---------------
+
+| ID    | Zone Name ID  | Zone Name | Zone Description
+| ----- | ------------- |---------- | ----------------
+| 1     | Z_RMAN2       | RICHM     | Richman
+| 2     | Z_GOLF1       | GOLF      | GWC and Golfing Society
+| 3     | Z_GOLF3       | GOLF      | GWC and Golfing Society
+| 4     | Z_RHL1        | ROCKF     | Rockford Hills
+| 5     | Z_RHL3        | ROCKF     | Rockford Hills
+| 6     | Z_RHL4        | ROCKF     | Rockford Hills
+| 7     | Z_MWOD1       | MORN      | Morningwood
+| 8     | Z_MWOD2       | MORN      | Morningwood
+| 9     | Z_RHL0        | ROCKF     | Rockford Hills
+| 10    | Z_RHL9        | ROCKF     | Rockford Hills
+| 11    | Z_MVS2        | MOVIE     | Richards Majestic
+| 12    | Z_MVS3        | MOVIE     | Richards Majestic
+| 13    | Z_MVS4        | MOVIE     | Richards Majestic
+| 14    | Z_RHL11       | ROCKF     | Rockford Hills
+| 15    | Z_RHL7        | ROCKF     | Rockford Hills
+| 16    | Z_RHL10       | ROCKF     | Rockford Hills
+| 17    | Z_RHL6        | ROCKF     | Rockford Hills
+| 18    | Z_RHL2        | ROCKF     | Rockford Hills
+| 19    | Z_RHL5        | ROCKF     | Rockford Hills
+| 20    | Z_RHL13       | ROCKF     | Rockford Hills
+| 21    | Z_KORT5       | KOREAT    | Little Seoul
+| 22    | Z_KORT4       | KOREAT    | Little Seoul
+| 23    | Z_KORT6       | KOREAT    | Little Seoul
+| 24    | Z_KORT7       | KOREAT    | Little Seoul
+| 25    | Z_KORT8       | KOREAT    | Little Seoul
+| 26    | Z_KORT1       | KOREAT    | Little Seoul
+| 27    | Z_KORT2       | KOREAT    | Little Seoul
+| 28    | Z_MVS5        | MOVIE     | Richards Majestic
+| 29    | Z_MVS1        | MOVIE     | Richards Majestic
+| 30    | Z_KORT9       | KOREAT    | Little Seoul
+| 31    | Z_LP2         | LOSPUER   | La Puerta
+| 32    | Z_LP4         | LOSPUER   | La Puerta
+| 33    | Z_MIRR        | MIRR      | Mirror Park
+| 34    | Z_EVi3        | EAST_V    | East Vinewood
+| 35    | Z_EVi2        | EAST_V    | East Vinewood
+| 36    | Z_LP1         | LOSPUER   | La Puerta
+| 37    | Z_DELPa       | DELPE     | Del Perro
+| 38    | Z_DELPb       | DELPE     | Del Perro
+| 39    | Z_DELPf       | DELPE     | Del Perro
+| 40    | Z_DELPe       | DELPE     | Del Perro
+| 41    | Z_DELPd       | DELPE     | Del Perro
+| 42    | ZPCBFd        | PBLUFF    | Pacific Bluffs
+| 43    | ZPCBFf        | PBLUFF    | Pacific Bluffs
+| 44    | Z_AIR2        | AIRP      | Los Santos International Airport
+| 45    | Z_CHi3        | TATAMO    | Tataviam Mountains
+| 46    | FrW2          | MURRI     | Murrieta Heights
+| 47    | FrW4          | LMESA     | La Mesa
+| 48    | FrW5          | MIRR      | Mirror Park
+| 49    | FrW7          | VINE      | Vinewood
+| 50    | FrW8          | ROCKF     | Rockford Hills
+| 51    | FrW9          | KOREAT    | Little Seoul
+| 52    | FrW10         | DOWNT     | Downtown
+| 53    | FrW11         | KOREAT    | Little Seoul
+| 54    | Z_KORT3       | KOREAT    | Little Seoul
+| 55    | FrW84         | STRAW     | Strawberry
+| 56    | FrW12         | KOREAT    | Little Seoul
+| 57    | FrW14         | STRAW     | Strawberry
+| 58    | FrW16         | DOWNT     | Downtown
+| 59    | PrLog         | PROL      | Prologue / North Yankton
+| 60    | RANC2         | RANCHO    | Rancho
+| 61    | RANC4         | RANCHO    | Rancho
+| 62    | RANC5         | RANCHO    | Rancho
+| 63    | RANC3         | RANCHO    | Rancho
+| 64    | SCCHA1        | CHAMH     | Chamberlain Hills
+| 65    | Straw2        | STRAW     | Strawberry
+| 66    | SCBALL3       | DAVIS     | Davis
+| 67    | SCBALL2       | DAVIS     | Davis
+| 68    | SCBALL1       | DAVIS     | Davis
+| 69    | SCBALL4       | DAVIS     | Davis
+| 70    | SCBALL5       | DAVIS     | Davis
+| 71    | SCBALL6       | DAVIS     | Davis
+| 72    | RANC1         | RANCHO    | Rancho
+| 73    | SCCHA2        | CHAMH     | Chamberlain Hills
+| 74    | Straw1        | STRAW     | Strawberry
+| 75    | FrW66         | LAGO      | Lago Zancudo
+| 76    | FrW67         | LAGO      | Lago Zancudo
+| 77    | FrW70         | CHU       | Chumash
+| 78    | FrW71         | CHU       | Chumash
+| 79    | FrW68         | TONGVAH   | Tongva Hills
+| 80    | FrW69         | CHU       | Chumash
+| 81    | FrW72         | CHU       | Chumash
+| 82    | FrW73         | BHAMCA    | Banham Canyon
+| 83    | FrW74         | BHAMCA    | Banham Canyon
+| 84    | FrW75         | PBLUFF    | Pacific Bluffs
+| 85    | FrW76         | PBLUFF    | Pacific Bluffs
+| 86    | FrW65         | NCHU      | North Chumash
+| 87    | FrW64         | NCHU      | North Chumash
+| 88    | FrW63         | CANNY     | Raton Canyon
+| 89    | FrW62         | CANNY     | Raton Canyon
+| 90    | FrW61         | CMSW      | Chiliad Mountain State Wilderness
+| 91    | FrW60         | CMSW      | Chiliad Mountain State Wilderness
+| 92    | FrW59         | CMSW      | Chiliad Mountain State Wilderness
+| 93    | FrW58         | CMSW      | Chiliad Mountain State Wilderness
+| 94    | FrW56         | CMSW      | Chiliad Mountain State Wilderness
+| 95    | FrW57         | CMSW      | Chiliad Mountain State Wilderness
+| 96    | FrW55         | CMSW      | Chiliad Mountain State Wilderness
+| 97    | FrW53         | PALFOR    | Paleto Forest
+| 98    | FrW52         | PALFOR    | Paleto Forest
+| 99    | FrW51         | PALFOR    | Paleto Forest
+| 100   | FrW50         | PALETO    | Paleto Bay
+| 101   | FrW49         | PALETO    | Paleto Bay
+| 102   | FrW48         | PALETO    | Paleto Bay
+| 103   | FrW47         | PALETO    | Paleto Bay
+| 104   | FrW46         | PALETO    | Paleto Bay
+| 105   | FrW45         | PALETO    | Paleto Bay
+| 106   | FrW42         | MTCHIL    | Mount Chiliad
+| 107   | FrW43         | MTCHIL    | Mount Chiliad
+| 108   | FrW39         | MTGORDO   | Mount Gordo
+| 109   | FrW41         | BRADP     | Braddock Pass
+| 110   | FrW40         | MTGORDO   | Mount Gordo
+| 111   | FrW38         | SANCHIA   | San Chianski Mountain Range
+| 112   | FrW37         | SANCHIA   | San Chianski Mountain Range
+| 113   | FrW36         | SANCHIA   | San Chianski Mountain Range
+| 114   | FrW35         | SANCHIA   | San Chianski Mountain Range
+| 115   | FrW34         | SANCHIA   | San Chianski Mountain Range
+| 116   | FrW33         | SANCHIA   | San Chianski Mountain Range
+| 117   | FrW32         | SANCHIA   | San Chianski Mountain Range
+| 118   | FrW31         | DESRT     | Grand Senora Desert
+| 119   | FrW30         | DESRT     | Grand Senora Desert
+| 120   | FrW29         | DESRT     | Grand Senora Desert
+| 121   | FrW27         | DESRT     | Grand Senora Desert
+| 122   | FrW26         | DESRT     | Grand Senora Desert
+| 123   | FrW25         | WINDF     | Ron Alternates Wind Farm
+| 124   | FrW24         | WINDF     | Ron Alternates Wind Farm
+| 125   | FrW23         | WINDF     | Ron Alternates Wind Farm
+| 126   | FrW20         | TATAMO    | Tataviam Mountains
+| 127   | FrW22         | WINDF     | Ron Alternates Wind Farm
+| 128   | FrW21         | WINDF     | Ron Alternates Wind Farm
+| 129   | FrW19         | TATAMO    | Tataviam Mountains
+| 130   | FrW18         | PALHIGH   | Palomino Highlands
+| 131   | FrW13         | MURRI     | Murrieta Heights
+| 132   | FrW83         | PALHIGH   | Palomino Highlands
+| 133   | FrW77         | PALHIGH   | Palomino Highlands
+| 134   | FrW17         | PALHIGH   | Palomino Highlands
+| 135   | FrW85         | PALHIGH   | Palomino Highlands
+| 136   | Pbox2         | PBOX      | Pillbox Hill
+| 137   | Pbox1         | PBOX      | Pillbox Hill
+| 138   | FASH          | TEXTI     | Textile City
+| 139   | SKID          | SKID      | Mission Row
+| 140   | Pbox3         | PBOX      | Pillbox Hill
+| 141   | Pbox4         | PBOX      | Pillbox Hill
+| 142   | VesBe3        | BEACH     | Vespucci Beach
+| 143   | VesBe5        | BEACH     | Vespucci Beach
+| 144   | VesBe4        | BEACH     | Vespucci Beach
+| 145   | VesBe9        | BEACH     | Vespucci Beach
+| 146   | FrW28         | DESRT     | Grand Senora Desert
+| 147   | FrW81         | DESRT     | Grand Senora Desert
+| 148   | FrW80         | JAIL      | Bolingbroke Penitentiary
+| 149   | FrW78         | CHIL      | Vinewood Hills
+| 150   | FrW79         | CHIL      | Vinewood Hills
+| 151   | FrW82         | DESRT     | Grand Senora Desert
+| 152   | ZJail1        | JAIL      | Bolingbroke Penitentiary
+| 153   | ZJail2        | JAIL      | Bolingbroke Penitentiary
+| 154   | ZJail3        | JAIL      | Bolingbroke Penitentiary
+| 155   | ZJail4        | JAIL      | Bolingbroke Penitentiary
+| 156   | G_FAM         | CHAMH     | Chamberlain Hills
+| 157   | G_VAGOS       | LMESA     | La Mesa
+| 158   | Z_STAD1       | STAD      | Maze Bank Arena
+| 159   | Z_STAD2       | STAD      | Maze Bank Arena
+| 160   | Z_CHi4        | CHIL      | Vinewood Hills
+| 161   | Z_EVi         | EAST_V    | East Vinewood
+| 162   | Z_EVi4        | EAST_V    | East Vinewood
+| 163   | Z_CHi6        | TATAMO    | Tataviam Mountains
+| 164   | ZTerm         | TERMINA   | Terminal
+| 165   | ZBann1        | BANNING   | Banning
+| 166   | ZElys1        | ELYSIAN   | Elysian Island
+| 167   | ZElys         | ELYSIAN   | Elysian Island
+| 168   | ZDTVine       | DTVINE    | Downtown Vinewood
+| 169   | ZEclp         | WVINE     | West Vinewood
+| 170   | ZEclp1        | WVINE     | West Vinewood
+| 171   | ZWVin         | WVINE     | West Vinewood
+| 172   | ZWVin1        | WVINE     | West Vinewood
+| 173   | ZBur1         | BURTON    | Burton
+| 174   | ZBur2         | BURTON    | Burton
+| 175   | ZRGln         | RGLEN     | Richman Glen
+| 176   | Z_GOLF2       | GOLF      | GWC and Golfing Society
+| 177   | Z_RMAN3       | RICHM     | Richman
+| 178   | Z_RMAN6       | RICHM     | Richman
+| 179   | Z_RMAN7       | RICHM     | Richman
+| 180   | ZPCBFc        | PBLUFF    | Pacific Bluffs
+| 181   | ZPCBFg        | PBLUFF    | Pacific Bluffs
+| 182   | ZPCBFe        | PBLUFF    | Pacific Bluffs
+| 183   | ZPCBFb        | PBLUFF    | Pacific Bluffs
+| 184   | Z_Marl        | OBSERV    | Galileo Observatory
+| 185   | Z_Gal         | GALLI     | Galileo Park
+| 186   | ZBtree        | BAYTRE    | Baytree Canyon
+| 187   | ZBtree1       | BAYTRE    | Baytree Canyon
+| 188   | ZVCan4        | VCANA     | Vespucci Canals
+| 189   | ZVCan3        | VCANA     | Vespucci Canals
+| 190   | ZVCan10       | VCANA     | Vespucci Canals
+| 191   | ZVCan5        | VCANA     | Vespucci Canals
+| 192   | ZVCan9        | VCANA     | Vespucci Canals
+| 193   | ZVCan8        | VCANA     | Vespucci Canals
+| 194   | ZVCan7        | VCANA     | Vespucci Canals
+| 195   | ZPDSO2        | DELSOL    | La Puerta
+| 196   | ZPDSO1        | DELSOL    | La Puerta
+| 197   | ZPDSO         | DELSOL    | La Puerta
+| 198   | ZPDSO4        | DELSOL    | La Puerta
+| 199   | ZPDSO3        | DELSOL    | La Puerta
+| 200   | ZVCan6        | VCANA     | Vespucci Canals
+| 201   | ZVCan2        | VCANA     | Vespucci Canals
+| 202   | ZVCan1        | VCANA     | Vespucci Canals
+| 203   | ZVCan         | VCANA     | Vespucci Canals
+| 204   | Z_Alta1       | ALTA      | Alta
+| 205   | ZBur3         | BURTON    | Burton
+| 206   | ZBur4         | BURTON    | Burton
+| 207   | FrW15         | LMESA     | La Mesa
+| 208   | ZPBay7        | PALFOR    | Paleto Forest
+| 209   | ZPBay6        | PALFOR    | Paleto Forest
+| 210   | ZPBay5        | PALETO    | Paleto Bay
+| 211   | ZPBay3        | PALETO    | Paleto Bay
+| 212   | ZPBay2        | PALETO    | Paleto Bay
+| 213   | ZPBay1        | PALETO    | Paleto Bay
+| 214   | ZPBay         | PALETO    | Paleto Bay
+| 215   | Btun          | BRADT     | Braddock Tunnel
+| 216   | Btun1         | BRADT     | Braddock Tunnel
+| 217   | Btun2         | BRADT     | Braddock Tunnel
+| 218   | Btun3         | BRADT     | Braddock Tunnel
+| 219   | Btun4         | BRADT     | Braddock Tunnel
+| 220   | Btun5         | BRADT     | Braddock Tunnel
+| 221   | Btun6         | BRADT     | Braddock Tunnel
+| 222   | Btun7         | BRADT     | Braddock Tunnel
+| 223   | Btun8         | BRADT     | Braddock Tunnel
+| 224   | Btun9         | BRADT     | Braddock Tunnel
+| 225   | Btun10        | BRADT     | Braddock Tunnel
+| 226   | Btun11        | BRADT     | Braddock Tunnel
+| 227   | Btun12        | BRADT     | Braddock Tunnel
+| 228   | Btun13        | BRADT     | Braddock Tunnel
+| 229   | Btun14        | BRADT     | Braddock Tunnel
+| 230   | Btun15        | BRADT     | Braddock Tunnel
+| 231   | Grape         | GRAPES    | Grapeseed
+| 232   | MJos          | MTCHIL    | Mount Chiliad
+| 233   | Z_Sand1       | SANDY     | Sandy Shores
+| 234   | ASea2         | ALAMO     | Alamo Sea
+| 235   | ASea1         | ALAMO     | Alamo Sea
+| 236   | ASea          | ALAMO     | Alamo Sea
+| 237   | Slab1         | SLAB      | Stab City
+| 238   | Slab2         | SLAB      | Stab City
+| 239   | ASea3         | ALAMO     | Alamo Sea
+| 240   | ASea4         | ALAMO     | Alamo Sea
+| 241   | ASea5         | ALAMO     | Alamo Sea
+| 242   | ELBur         | EBURO     | El Burro Heights
+| 243   | Cypr          | CYPRE     | Cypress Flats
+| 244   | Cypr1         | CYPRE     | Cypress Flats
+| 245   | FrW1          | MURRI     | Murrieta Heights
+| 246   | ZMesa2        | LMESA     | La Mesa
+| 247   | ZMesa1        | LMESA     | La Mesa
+| 248   | ZMesa         | LMESA     | La Mesa
+| 249   | ZMurri3       | MURRI     | Murrieta Heights
+| 250   | ZMurri2       | MURRI     | Murrieta Heights
+| 251   | ZMurri1       | EBURO     | El Burro Heights
+| 252   | ZMurri        | MURRI     | Murrieta Heights
+| 253   | Army          | ARMYB     | Fort Zancudo
+| 254   | Army1         | ARMYB     | Fort Zancudo
+| 255   | RCANY         | CANNY     | Raton Canyon
+| 256   | Harmon        | HARMO     | Harmony
+| 257   | WetLD2        | LAGO      | Lago Zancudo
+| 258   | Dsut12        | DESRT     | Grand Senora Desert
+| 259   | Dsut11        | DESRT     | Grand Senora Desert
+| 260   | Dsut10        | DESRT     | Grand Senora Desert
+| 261   | Dsut5         | DESRT     | Grand Senora Desert
+| 262   | Dsut4         | DESRT     | Grand Senora Desert
+| 263   | Dsut7         | DESRT     | Grand Senora Desert
+| 264   | Dsut9         | DESRT     | Grand Senora Desert
+| 265   | Dsut8         | DESRT     | Grand Senora Desert
+| 266   | Dsut3         | DESRT     | Grand Senora Desert
+| 267   | Dsut6         | DESRT     | Grand Senora Desert
+| 268   | Z_STAD3       | STAD      | Maze Bank Arena
+| 269   | ZPoRT3        | ZP_ORT    | Port of South Los Santos
+| 270   | ZdBeO         | DELBE     | Del Perro Beach
+| 271   | ZdBeM         | DELBE     | Del Perro Beach
+| 272   | ZdBeN         | DELBE     | Del Perro Beach
+| 273   | ZdBeA         | DELBE     | Del Perro Beach
+| 274   | ZdBeB         | DELBE     | Del Perro Beach
+| 275   | ZdBeC         | DELBE     | Del Perro Beach
+| 276   | ZdBeK         | DELBE     | Del Perro Beach
+| 277   | ZdBeH         | DELBE     | Del Perro Beach
+| 278   | ZdBeE         | DELBE     | Del Perro Beach
+| 279   | ZdBeD         | DELBE     | Del Perro Beach
+| 280   | ZdBeG         | DELBE     | Del Perro Beach
+| 281   | ZdBeF         | DELBE     | Del Perro Beach
+| 282   | ZdBeI         | DELBE     | Del Perro Beach
+| 283   | Army4         | ARMYB     | Fort Zancudo
+| 284   | Army3         | ARMYB     | Fort Zancudo
+| 285   | Army2         | ARMYB     | Fort Zancudo
+| 286   | Cide90        | GREATC    | Great Chaparral
+| 287   | PB_BeC        | PBLUFF    | Pacific Bluffs
+| 288   | PB_BeD        | PBLUFF    | Pacific Bluffs
+| 289   | PB_BeG        | PBLUFF    | Pacific Bluffs
+| 290   | PB_BeH        | PBLUFF    | Pacific Bluffs
+| 291   | PB_BeA        | PBLUFF    | Pacific Bluffs
+| 292   | PB_BeE        | PBLUFF    | Pacific Bluffs
+| 293   | ZPCBF         | PBLUFF    | Pacific Bluffs
+| 294   | ZPCBFh        | PBLUFF    | Pacific Bluffs
+| 295   | ZPCBFi        | PBLUFF    | Pacific Bluffs
+| 296   | ZPCBFk        | PBLUFF    | Pacific Bluffs
+| 297   | ZPCBFl        | PBLUFF    | Pacific Bluffs
+| 298   | ZPCBFm        | PBLUFF    | Pacific Bluffs
+| 299   | ZPCBFn        | PBLUFF    | Pacific Bluffs
+| 300   | ZPCBFo        | PBLUFF    | Pacific Bluffs
+| 301   | ZPCBFp        | PBLUFF    | Pacific Bluffs
+| 302   | VesBe8        | BEACH     | Vespucci Beach
+| 303   | Z_VES3        | VESP      | Vespucci
+| 304   | Z_VES2        | VESP      | Vespucci
+| 305   | Z_VES1        | VESP      | Vespucci
+| 306   | Z_VES4        | VESP      | Vespucci
+| 307   | Z_VES5        | VESP      | Vespucci
+| 308   | Z_DELPg       | DELPE     | Del Perro
+| 309   | Z_DELPh       | DELPE     | Del Perro
+| 310   | Z_DELPi       | DELPE     | Del Perro
+| 311   | Z_DELPj       | DELPE     | Del Perro
+| 312   | Z_DELPk       | DELPE     | Del Perro
+| 313   | Z_DELPl       | DELPE     | Del Perro
+| 314   | Z_DELPm       | DELPE     | Del Perro
+| 315   | Z_DELPn       | DELPE     | Del Perro
+| 316   | Z_DELPo       | DELPE     | Del Perro
+| 317   | Z_DELPp       | DELPE     | Del Perro
+| 318   | Z_DELPq       | DELPE     | Del Perro
+| 319   | Z_DELPs       | DELPE     | Del Perro
+| 320   | Z_DELPr       | DELPE     | Del Perro
+| 321   | Z_DELPc       | DELPE     | Del Perro
+| 322   | LstMC1        | EAST_V    | East Vinewood
+| 323   | LstMC2        | EAST_V    | East Vinewood
+| 324   | FrW86         | CHIL      | Vinewood Hills
+| 325   | FrW115        | CHIL      | Vinewood Hills
+| 326   | FrW87         | CHIL      | Vinewood Hills
+| 327   | FrW92         | CHIL      | Vinewood Hills
+| 328   | FrW91         | CHIL      | Vinewood Hills
+| 329   | FrW88         | CHIL      | Vinewood Hills
+| 330   | FrW89         | CHIL      | Vinewood Hills
+| 331   | FrW90         | CHIL      | Vinewood Hills
+| 332   | Z_Hor1        | HORS      | Vinewood Racetrack
+| 333   | Z_Hor2        | HORS      | Vinewood Racetrack
+| 334   | Z_Hor3        | HORS      | Vinewood Racetrack
+| 335   | Z_Hor4        | HORS      | Vinewood Racetrack
+| 336   | Z_Hor5        | HORS      | Vinewood Racetrack
+| 337   | Z_Hor6        | HORS      | Vinewood Racetrack
+| 338   | Z_Hor8        | EAST_V    | East Vinewood
+| 339   | Z_Hor10       | EAST_V    | East Vinewood
+| 340   | Z_Hor9        | EAST_V    | East Vinewood
+| 341   | FrW93         | CHIL      | Vinewood Hills
+| 342   | FrW94         | CHIL      | Vinewood Hills
+| 343   | FrW95         | CHIL      | Vinewood Hills
+| 344   | FrW96         | CHIL      | Vinewood Hills
+| 345   | FrW97         | EAST_V    | East Vinewood
+| 346   | FrW98         | EAST_V    | East Vinewood
+| 347   | FrW100        | HAWICK    | Hawick
+| 348   | FrW99         | HAWICK    | Hawick
+| 349   | FrW102        | EAST_V    | East Vinewood
+| 350   | FrW101        | EAST_V    | East Vinewood
+| 351   | FrW103        | ALTA      | Alta
+| 352   | FrW104        | ALTA      | Alta
+| 353   | ZHWK1         | HAWICK    | Hawick
+| 354   | ZHWK2         | HAWICK    | Hawick
+| 355   | ZHWK3         | HAWICK    | Hawick
+| 356   | Z_Alta2       | ALTA      | Alta
+| 357   | Z_Alta3       | ALTA      | Alta
+| 358   | Z_Alta4       | ALTA      | Alta
+| 359   | Z_Hor7        | HORS      | Vinewood Racetrack
+| 360   | Z_RMAN4       | RICHM     | Richman
+| 361   | Z_RMAN5       | RICHM     | Richman
+| 362   | WetLD1        | LAGO      | Lago Zancudo
+| 363   | WetLD4        | LAGO      | Lago Zancudo
+| 364   | ZnCu1         | ZANCUDO   | Zancudo River
+| 365   | ZnCu2         | ZANCUDO   | Zancudo River
+| 366   | ZnCu3         | ZANCUDO   | Zancudo River
+| 367   | ZnCu4         | ZANCUDO   | Zancudo River
+| 368   | ZnCu18        | ZANCUDO   | Zancudo River
+| 369   | ZnCu19        | ZANCUDO   | Zancudo River
+| 370   | ZnCu6         | ZANCUDO   | Zancudo River
+| 371   | ZnCu11        | ZANCUDO   | Zancudo River
+| 372   | ZnCu10        | ZANCUDO   | Zancudo River
+| 373   | ZnCu9         | ZANCUDO   | Zancudo River
+| 374   | ZnCu8         | ZANCUDO   | Zancudo River
+| 375   | ZnCu7         | ZANCUDO   | Zancudo River
+| 376   | ZnCu20        | ZANCUDO   | Zancudo River
+| 377   | ZnCu5         | ZANCUDO   | Zancudo River
+| 378   | ZnCu12        | ZANCUDO   | Zancudo River
+| 379   | ZnCu13        | ZANCUDO   | Zancudo River
+| 380   | ZnCu17        | ZANCUDO   | Zancudo River
+| 381   | ZnCu15        | ZANCUDO   | Zancudo River
+| 382   | ZnCu16        | ZANCUDO   | Zancudo River
+| 383   | ZnCu14        | ZANCUDO   | Zancudo River
+| 384   | Dsut16        | DESRT     | Grand Senora Desert
+| 385   | Dsut13        | DESRT     | Grand Senora Desert
+| 386   | Dsut15        | DESRT     | Grand Senora Desert
+| 387   | Dsut14        | DESRT     | Grand Senora Desert
+| 388   | Dsut2         | DESRT     | Grand Senora Desert
+| 389   | Dsut1         | DESRT     | Grand Senora Desert
+| 390   | ZnCu21        | ZANCUDO   | Zancudo River
+| 391   | ZnCu22        | DESRT     | Grand Senora Desert
+| 392   | ZnCu23        | ZANCUDO   | Zancudo River
+| 393   | ZnCu24        | ZANCUDO   | Zancudo River
+| 394   | ZnCu25        | ZANCUDO   | Zancudo River
+| 395   | ZnCu26        | ZANCUDO   | Zancudo River
+| 396   | ZnCu27        | ZANCUDO   | Zancudo River
+| 397   | Wind1         | WINDF     | Ron Alternates Wind Farm
+| 398   | Wind8         | WINDF     | Ron Alternates Wind Farm
+| 399   | Wind7         | WINDF     | Ron Alternates Wind Farm
+| 400   | Wind6         | WINDF     | Ron Alternates Wind Farm
+| 401   | Wind5         | WINDF     | Ron Alternates Wind Farm
+| 402   | Wind4         | WINDF     | Ron Alternates Wind Farm
+| 403   | Wind3         | WINDF     | Ron Alternates Wind Farm
+| 404   | Wind2         | WINDF     | Ron Alternates Wind Farm
+| 405   | VesBe7        | BEACH     | Vespucci Beach
+| 406   | VesBe12       | BEACH     | Vespucci Beach
+| 407   | VesBe11       | BEACH     | Vespucci Beach
+| 408   | VesBe13       | BEACH     | Vespucci Beach
+| 409   | VesBe14       | BEACH     | Vespucci Beach
+| 410   | Cide2         | MTCHIL    | Mount Chiliad
+| 411   | Cide3         | MTCHIL    | Mount Chiliad
+| 412   | Cide1         | MTCHIL    | Mount Chiliad
+| 413   | Cide4         | CMSW      | Chiliad Mountain State Wilderness
+| 414   | Cide8         | CMSW      | Chiliad Mountain State Wilderness
+| 415   | Cide7         | CMSW      | Chiliad Mountain State Wilderness
+| 416   | Cide6         | CMSW      | Chiliad Mountain State Wilderness
+| 417   | Cide24        | CMSW      | Chiliad Mountain State Wilderness
+| 418   | Cide5         | CMSW      | Chiliad Mountain State Wilderness
+| 419   | Cide9         | MTCHIL    | Mount Chiliad
+| 420   | Cide10        | MTCHIL    | Mount Chiliad
+| 421   | Cide11        | PALFOR    | Paleto Forest
+| 422   | Cide12        | PALFOR    | Paleto Forest
+| 423   | Cide13        | PALFOR    | Paleto Forest
+| 424   | Cide14        | PALFOR    | Paleto Forest
+| 425   | Cide15        | PALETO    | Paleto Bay
+| 426   | Cide16        | PALETO    | Paleto Bay
+| 427   | Cide19        | MTCHIL    | Mount Chiliad
+| 428   | Cide17        | MTCHIL    | Mount Chiliad
+| 429   | Cide23        | MTCHIL    | Mount Chiliad
+| 430   | Cide21        | PALETO    | Paleto Bay
+| 431   | Cide20        | MTCHIL    | Mount Chiliad
+| 432   | Cide22        | MTCHIL    | Mount Chiliad
+| 433   | Cide18        | MTCHIL    | Mount Chiliad
+| 434   | Z_RMAN1       | RICHM     | Richman
+| 435   | Cide25        | MTCHIL    | Mount Chiliad
+| 436   | Cide26        | MTCHIL    | Mount Chiliad
+| 437   | Cide27        | GRAPES    | Grapeseed
+| 438   | Cide28        | GRAPES    | Grapeseed
+| 439   | Cide29        | GRAPES    | Grapeseed
+| 440   | Cide30        | GRAPES    | Grapeseed
+| 441   | Cide31        | SANDY     | Sandy Shores
+| 442   | Cide32        | SANDY     | Sandy Shores
+| 443   | Cide33        | SANCHIA   | San Chianski Mountain Range
+| 444   | Cide35        | DESRT     | Grand Senora Desert
+| 445   | Cide34        | SANDY     | Sandy Shores
+| 446   | Cide38        | MTJOSE    | Mount Josiah
+| 447   | Cide37        | MTJOSE    | Mount Josiah
+| 448   | Cide36        | CANNY     | Raton Canyon
+| 449   | Cide39        | MTJOSE    | Mount Josiah
+| 450   | Cide44        | MTJOSE    | Mount Josiah
+| 451   | Cide43        | MTJOSE    | Mount Josiah
+| 452   | Cide42        | MTJOSE    | Mount Josiah
+| 453   | Cide41        | MTJOSE    | Mount Josiah
+| 454   | Cide40        | MTJOSE    | Mount Josiah
+| 455   | Cide45        | MTJOSE    | Mount Josiah
+| 456   | Cide46        | ZANCUDO   | Zancudo River
+| 457   | Cide74        | GREATC    | Great Chaparral
+| 458   | Cide75        | GREATC    | Great Chaparral
+| 459   | Cide49        | GREATC    | Great Chaparral
+| 460   | Cide50        | GREATC    | Great Chaparral
+| 461   | Cide51        | GREATC    | Great Chaparral
+| 462   | Cide52        | GREATC    | Great Chaparral
+| 463   | Cide53        | GREATC    | Great Chaparral
+| 464   | Cide54        | GREATC    | Great Chaparral
+| 465   | Cide55        | GREATC    | Great Chaparral
+| 466   | Cide56        | GREATC    | Great Chaparral
+| 467   | Cide57        | GREATC    | Great Chaparral
+| 468   | Cide47        | GREATC    | Great Chaparral
+| 469   | Cide58        | GREATC    | Great Chaparral
+| 470   | Cide48        | GREATC    | Great Chaparral
+| 471   | Cide67        | CHIL      | Vinewood Hills
+| 472   | Cide66        | DESRT     | Grand Senora Desert
+| 473   | Cide70        | TATAMO    | Tataviam Mountains
+| 474   | Cide68        | TATAMO    | Tataviam Mountains
+| 475   | Cide69        | TATAMO    | Tataviam Mountains
+| 476   | Cide71        | TATAMO    | Tataviam Mountains
+| 477   | Cide72        | TATAMO    | Tataviam Mountains
+| 478   | Cide73        | TATAMO    | Tataviam Mountains
+| 479   | Cide76        | MTCHIL    | Mount Chiliad
+| 480   | FrW44         | MTCHIL    | Mount Chiliad
+| 481   | Qua1          | ZQ_UAR    | Davis Quartz
+| 482   | Qua2          | ZQ_UAR    | Davis Quartz
+| 483   | Qua3          | ZQ_UAR    | Davis Quartz
+| 484   | FrW105        | DESRT     | Grand Senora Desert
+| 485   | FrW106        | DESRT     | Grand Senora Desert
+| 486   | FrW107        | DESRT     | Grand Senora Desert
+| 487   | FrW108        | JAIL      | Bolingbroke Penitentiary
+| 488   | FrW109        | BHAMCA    | Banham Canyon
+| 489   | FrW110        | BHAMCA    | Banham Canyon
+| 490   | FrW111        | BHAMCA    | Banham Canyon
+| 491   | FrW112        | BHAMCA    | Banham Canyon
+| 492   | FrW113        | BHAMCA    | Banham Canyon
+| 493   | FrW114        | BHAMCA    | Banham Canyon
+| 494   | Cide77        | BHAMCA    | Banham Canyon
+| 495   | Z_AIR1        | AIRP      | Los Santos International Airport
+| 496   | Z_LP3         | LOSPUER   | La Puerta
+| 497   | VesBe1        | BEACH     | Vespucci Beach
+| 498   | Vesbe15       | BEACH     | Vespucci Beach
+| 499   | RANC6         | RANCHO    | Rancho
+| 500   | Cide88        | SANCHIA   | San Chianski Mountain Range
+| 501   | Cide86        | SANCHIA   | San Chianski Mountain Range
+| 502   | Cide81        | SANCHIA   | San Chianski Mountain Range
+| 503   | Cide89        | SANCHIA   | San Chianski Mountain Range
+| 504   | Cide87        | MTGORDO   | Mount Gordo
+| 505   | Cide83        | MTGORDO   | Mount Gordo
+| 506   | Cide82        | MTGORDO   | Mount Gordo
+| 507   | ZOce10        | CMSW      | Chiliad Mountain State Wilderness
+| 508   | ZOce8         | CMSW      | Chiliad Mountain State Wilderness
+| 509   | ZOce7         | CMSW      | Chiliad Mountain State Wilderness
+| 510   | ZOce6         | CMSW      | Chiliad Mountain State Wilderness
+| 511   | ZOce4         | OCEANA    | Pacific Ocean
+| 512   | ZOce2         | NCHU      | North Chumash
+| 513   | ZOce5         | OCEANA    | Pacific Ocean
+| 514   | ZOce11        | OCEANA    | Pacific Ocean
+| 515   | ZOce9         | OCEANA    | Pacific Ocean
+| 516   | ZOce25        | OCEANA    | Pacific Ocean
+| 517   | ZOce24        | OCEANA    | Pacific Ocean
+| 518   | ZOce23        | OCEANA    | Pacific Ocean
+| 519   | ZOce22        | OCEANA    | Pacific Ocean
+| 520   | ZOce20        | OCEANA    | Pacific Ocean
+| 521   | ZOce19        | OCEANA    | Pacific Ocean
+| 522   | ZOce18        | OCEANA    | Pacific Ocean
+| 523   | ZOce17        | OCEANA    | Pacific Ocean
+| 524   | ZOce16        | OCEANA    | Pacific Ocean
+| 525   | ZOce34        | OCEANA    | Pacific Ocean
+| 526   | ZOce27        | OCEANA    | Pacific Ocean
+| 527   | ZOce30        | OCEANA    | Pacific Ocean
+| 528   | ZOce31        | OCEANA    | Pacific Ocean
+| 529   | ZOce32        | OCEANA    | Pacific Ocean
+| 530   | ZOce33        | OCEANA    | Pacific Ocean
+| 531   | ZOce36        | OCEANA    | Pacific Ocean
+| 532   | ZOce37        | OCEANA    | Pacific Ocean
+| 533   | ZOce13        | OCEANA    | Pacific Ocean
+| 534   | FrW116        | DOWNT     | Downtown
+| 535   | VesBe2        | BEACH     | Vespucci Beach
+| 536   | VesBe17       | BEACH     | Vespucci Beach
+| 537   | ZPDSO5        | DELSOL    | La Puerta
+| 538   | Hipp01        | WINDF     | Ron Alternates Wind Farm
+| 539   | Hipp02        | WINDF     | Ron Alternates Wind Farm
+| 540   | Wind9         | WINDF     | Ron Alternates Wind Farm
+| 541   | Wind10        | WINDF     | Ron Alternates Wind Farm
+| 542   | Cult1         | CMSW      | Chiliad Mountain State Wilderness
+| 543   | Cult3         | CMSW      | Chiliad Mountain State Wilderness
+| 544   | Cult2         | CMSW      | Chiliad Mountain State Wilderness
+| 545   | ZdBeS         | DELBE     | Del Perro Beach
+| 546   | ZProc1        | PROCOB    | Procopio Beach
+| 547   | ZProc2        | PROCOB    | Procopio Beach
+| 548   | FrW117        | BRADP     | Braddock Pass
+| 549   | FrW118        | BRADP     | Braddock Pass
+| 550   | ZOce86        | OCEANA    | Pacific Ocean
+| 551   | ZOce28        | OCEANA    | Pacific Ocean
+| 552   | ZOce49        | OCEANA    | Pacific Ocean
+| 553   | ZOce51        | OCEANA    | Pacific Ocean
+| 554   | ZOce50        | OCEANA    | Pacific Ocean
+| 555   | ZOce46        | OCEANA    | Pacific Ocean
+| 556   | ZOce47        | OCEANA    | Pacific Ocean
+| 557   | ZOce45        | OCEANA    | Pacific Ocean
+| 558   | CIDE80        | OCEANA    | Pacific Ocean
+| 559   | CIDE91        | MTGORDO   | Mount Gordo
+| 560   | CIDE92        | MTGORDO   | Mount Gordo
+| 561   | CIDE93        | MTGORDO   | Mount Gordo
+| 562   | CIDE94        | MTGORDO   | Mount Gordo
+| 563   | CIDE95        | MTGORDO   | Mount Gordo
+| 564   | CIDE96        | MTGORDO   | Mount Gordo
+| 565   | CIDE97        | MTGORDO   | Mount Gordo
+| 566   | CIDE136       | MTGORDO   | Mount Gordo
+| 567   | CIDE102       | MTGORDO   | Mount Gordo
+| 568   | CIDE99        | MTGORDO   | Mount Gordo
+| 569   | CIDE100       | MTGORDO   | Mount Gordo
+| 570   | CIDE101       | MTGORDO   | Mount Gordo
+| 571   | LHous         | ELGORL    | El Gordo Lighthouse
+| 572   | Cide79        | MTGORDO   | Mount Gordo
+| 573   | ZOce39        | OCEANA    | Pacific Ocean
+| 574   | ZOce38        | OCEANA    | Pacific Ocean
+| 575   | ZOce40        | OCEANA    | Pacific Ocean
+| 576   | ZOce41        | OCEANA    | Pacific Ocean
+| 577   | ZOce53        | OCEANA    | Pacific Ocean
+| 578   | ZOce42        | OCEANA    | Pacific Ocean
+| 579   | ZOce43        | OCEANA    | Pacific Ocean
+| 580   | ZOce48        | OCEANA    | Pacific Ocean
+| 581   | CIDE98        | MTGORDO   | Mount Gordo
+| 582   | ZOce52        | OCEANA    | Pacific Ocean
+| 583   | ZOce54        | OCEANA    | Pacific Ocean
+| 584   | CIDE111       | SANCHIA   | San Chianski Mountain Range
+| 585   | ZOce55        | OCEANA    | Pacific Ocean
+| 586   | ZOce56        | OCEANA    | Pacific Ocean
+| 587   | ZOce57        | OCEANA    | Pacific Ocean
+| 588   | CIDE113       | SANCHIA   | San Chianski Mountain Range
+| 589   | CIDE103       | MTGORDO   | Mount Gordo
+| 590   | CIDE104       | MTGORDO   | Mount Gordo
+| 591   | CIDE105       | MTGORDO   | Mount Gordo
+| 592   | CIDE106       | MTGORDO   | Mount Gordo
+| 593   | CIDE137       | MTGORDO   | Mount Gordo
+| 594   | CIDE107       | MTGORDO   | Mount Gordo
+| 595   | CIDE108       | MTGORDO   | Mount Gordo
+| 596   | CIDE109       | MTGORDO   | Mount Gordo
+| 597   | CIDE110       | MTGORDO   | Mount Gordo
+| 598   | CIDE134       | SANCHIA   | San Chianski Mountain Range
+| 599   | CIDE119       | SANCHIA   | San Chianski Mountain Range
+| 600   | CIDE118       | SANCHIA   | San Chianski Mountain Range
+| 601   | ZOce67        | SANCHIA   | San Chianski Mountain Range
+| 602   | ZOce66        | OCEANA    | Pacific Ocean
+| 603   | ZOce70        | OCEANA    | Pacific Ocean
+| 604   | CIDE114       | SANCHIA   | San Chianski Mountain Range
+| 605   | CIDE116       | SANCHIA   | San Chianski Mountain Range
+| 606   | CIDE117       | SANCHIA   | San Chianski Mountain Range
+| 607   | CIDE115       | SANCHIA   | San Chianski Mountain Range
+| 608   | ZOce63        | OCEANA    | Pacific Ocean
+| 609   | ZOce68        | OCEANA    | Pacific Ocean
+| 610   | ZOce59        | OCEANA    | Pacific Ocean
+| 611   | ZOce60        | OCEANA    | Pacific Ocean
+| 612   | ZOce61        | OCEANA    | Pacific Ocean
+| 613   | ZOce62        | OCEANA    | Pacific Ocean
+| 614   | ZOce64        | OCEANA    | Pacific Ocean
+| 615   | ZOce65        | OCEANA    | Pacific Ocean
+| 616   | ZOce71        | OCEANA    | Pacific Ocean
+| 617   | CIDE132       | MTCHIL    | Mount Chiliad
+| 618   | CIDE133       | BRADP     | Braddock Pass
+| 619   | ZOce72        | OCEANA    | Pacific Ocean
+| 620   | ZOce73        | OCEANA    | Pacific Ocean
+| 621   | ZOce74        | OCEANA    | Pacific Ocean
+| 622   | ZOce75        | OCEANA    | Pacific Ocean
+| 623   | ZOce76        | OCEANA    | Pacific Ocean
+| 624   | ZOce77        | OCEANA    | Pacific Ocean
+| 625   | ZOce78        | OCEANA    | Pacific Ocean
+| 626   | ZOce79        | OCEANA    | Pacific Ocean
+| 627   | ZOce81        | OCEANA    | Pacific Ocean
+| 628   | ZOce80        | OCEANA    | Pacific Ocean
+| 629   | ZOce82        | OCEANA    | Pacific Ocean
+| 630   | ZOce84        | OCEANA    | Pacific Ocean
+| 631   | KaPow4        | PALMPOW   | Palmer-Taylor Power Station
+| 632   | CIDE129       | WINDF     | Ron Alternates Wind Farm
+| 633   | CIDE128       | WINDF     | Ron Alternates Wind Farm
+| 634   | CIDE127       | WINDF     | Ron Alternates Wind Farm
+| 635   | CIDE126       | WINDF     | Ron Alternates Wind Farm
+| 636   | CIDE125       | WINDF     | Ron Alternates Wind Farm
+| 637   | CIDE124       | ZQ_UAR    | Davis Quartz
+| 638   | CIDE123       | SANCHIA   | San Chianski Mountain Range
+| 639   | CIDE121       | SANCHIA   | San Chianski Mountain Range
+| 640   | CIDE120       | SANCHIA   | San Chianski Mountain Range
+| 641   | CIDE122       | SANCHIA   | San Chianski Mountain Range
+| 642   | ZOce85        | OCEANA    | Pacific Ocean
+| 643   | CIDE135       | OCEANA    | Pacific Ocean
+| 644   | CIDE130       | WINDF     | Ron Alternates Wind Farm
+| 645   | Cide78        | BHAMCA    | Banham Canyon
+| 646   | ZOce21        | OCEANA    | Pacific Ocean
+| 647   | ZPDSO6        | DELSOL    | La Puerta
+| 648   | FrW120        | MIRR      | Mirror Park
+| 649   | FrW119        | MIRR      | Mirror Park
+| 650   | FrW122        | MIRR      | Mirror Park
+| 651   | FrW123        | MIRR      | Mirror Park
+| 652   | FrW121        | MIRR      | Mirror Park
+| 653   | FrW3          | MIRR      | Mirror Park
+| 654   | Z_GOLF4       | GOLF      | GWC and Golfing Society
+| 655   | Z_RHL8        | ROCKF     | Rockford Hills
+| 656   | FrW6          | VINE      | Vinewood
+| 657   | Z_Alta5       | ALTA      | Alta
+| 658   | Z_CHU8        | CHU       | Chumash
+| 659   | Z_CHU1        | CHU       | Chumash
+| 660   | Z_CHU         | CHU       | Chumash
+| 661   | Z_CHU7        | CHU       | Chumash
+| 662   | Z_CHU3        | CHU       | Chumash
+| 663   | ZOce89        | OCEANA    | Pacific Ocean
+| 664   | ZOce87        | OCEANA    | Pacific Ocean
+| 665   | ZOce88        | OCEANA    | Pacific Ocean
+| 666   | Z_CHU9        | CHU       | Chumash
+| 667   | Z_CHU6        | CHU       | Chumash
+| 668   | Z_CHU4        | CHU       | Chumash
+| 669   | Z_CHU2        | CHU       | Chumash
+| 670   | ZPBay4        | PALETO    | Paleto Bay
+| 671   | ZPBay9        | PALETO    | Paleto Bay
+| 672   | ZdBesb        | DELBE     | Del Perro Beach
+| 673   | ZdBesc        | DELBE     | Del Perro Beach
+| 674   | ZdBesd        | DELBE     | Del Perro Beach
+| 675   | ZdBese        | DELBE     | Del Perro Beach
+| 676   | ZOce90        | OCEANA    | Pacific Ocean
+| 677   | ZOce91        | OCEANA    | Pacific Ocean
+| 678   | ZOce92        | OCEANA    | Pacific Ocean
+| 679   | ZOce93        | OCEANA    | Pacific Ocean
+| 680   | ZdBeP         | DELBE     | Del Perro Beach
+| 681   | ZdBePa        | DELBE     | Del Perro Beach
+| 682   | ZdBePb        | DELBE     | Del Perro Beach
+| 683   | ZdBePc        | BEACH     | Vespucci Beach
+| 684   | ZdBePd        | DELBE     | Del Perro Beach
+| 685   | VesBe19       | DELBE     | Del Perro Beach
+| 686   | VesBe20       | BEACH     | Vespucci Beach
+| 687   | VesBe21       | BEACH     | Vespucci Beach
+| 688   | VesBe22       | BEACH     | Vespucci Beach
+| 689   | VesBe23       | BEACH     | Vespucci Beach
+| 690   | VesBe18       | BEACH     | Vespucci Beach
+| 691   | VesBe6        | BEACH     | Vespucci Beach
+| 692   | VesBe24       | BEACH     | Vespucci Beach
+| 693   | VesBe25       | BEACH     | Vespucci Beach
+| 694   | VesBe27       | BEACH     | Vespucci Beach
+| 695   | VesBe28       | BEACH     | Vespucci Beach
+| 696   | VesBe29       | BEACH     | Vespucci Beach
+| 697   | VesBe30       | BEACH     | Vespucci Beach
+| 698   | VesBe31       | BEACH     | Vespucci Beach
+| 699   | VesBe32       | BEACH     | Vespucci Beach
+| 700   | VesBe45       | BEACH     | Vespucci Beach
+| 701   | VesBe33       | BEACH     | Vespucci Beach
+| 702   | VesBe34       | BEACH     | Vespucci Beach
+| 703   | VesBe35       | BEACH     | Vespucci Beach
+| 704   | VesBe37       | BEACH     | Vespucci Beach
+| 705   | VesBe38       | BEACH     | Vespucci Beach
+| 706   | VesBe40       | BEACH     | Vespucci Beach
+| 707   | VesBe39       | BEACH     | Vespucci Beach
+| 708   | VesBe36       | BEACH     | Vespucci Beach
+| 709   | VesBe44       | BEACH     | Vespucci Beach
+| 710   | VesBe43       | BEACH     | Vespucci Beach
+| 711   | VesBe41       | BEACH     | Vespucci Beach
+| 712   | VesBe42       | BEACH     | Vespucci Beach
+| 713   | ZOce94        | OCEANA    | Pacific Ocean
+| 714   | ZOce95        | OCEANA    | Pacific Ocean
+| 715   | ZOce96        | OCEANA    | Pacific Ocean
+| 716   | ZOce97        | OCEANA    | Pacific Ocean
+| 717   | ZOce98        | OCEANA    | Pacific Ocean
+| 718   | ZOce99        | OCEANA    | Pacific Ocean
+| 719   | ZOce100       | OCEANA    | Pacific Ocean
+| 720   | ZOce101       | OCEANA    | Pacific Ocean
+| 721   | ZOce102       | OCEANA    | Pacific Ocean
+| 722   | ZOce103       | OCEANA    | Pacific Ocean
+| 723   | ZOce104       | OCEANA    | Pacific Ocean
+| 724   | ZOce106       | OCEANA    | Pacific Ocean
+| 725   | ZOce107       | OCEANA    | Pacific Ocean
+| 726   | ZOce108       | OCEANA    | Pacific Ocean
+| 727   | ZOce109       | OCEANA    | Pacific Ocean
+| 728   | ZOce105       | OCEANA    | Pacific Ocean
+| 729   | ZOce111       | OCEANA    | Pacific Ocean
+| 730   | ZOce112       | OCEANA    | Pacific Ocean
+| 731   | ZOce113       | OCEANA    | Pacific Ocean
+| 732   | ZOce114       | OCEANA    | Pacific Ocean
+| 733   | ZOce110       | OCEANA    | Pacific Ocean
+| 734   | ZOce115       | OCEANA    | Pacific Ocean
+| 735   | ZOce116       | OCEANA    | Pacific Ocean
+| 736   | ZOce117       | OCEANA    | Pacific Ocean
+| 737   | ZOce121       | OCEANA    | Pacific Ocean
+| 738   | ZOce120       | OCEANA    | Pacific Ocean
+| 739   | ZOce122       | OCEANA    | Pacific Ocean
+| 740   | ZOce119       | OCEANA    | Pacific Ocean
+| 741   | ZOce118       | OCEANA    | Pacific Ocean
+| 742   | ZOce131       | OCEANA    | Pacific Ocean
+| 743   | ZOce130       | OCEANA    | Pacific Ocean
+| 744   | ZOce128       | OCEANA    | Pacific Ocean
+| 745   | ZOce227       | OCEANA    | Pacific Ocean
+| 746   | ZOce125       | OCEANA    | Pacific Ocean
+| 747   | ZdBeTk        | DELBE     | Del Perro Beach
+| 748   | ZOce126       | OCEANA    | Pacific Ocean
+| 749   | ZOce127       | OCEANA    | Pacific Ocean
+| 750   | ZOce132       | OCEANA    | Pacific Ocean
+| 751   | ZOce133       | OCEANA    | Pacific Ocean
+| 752   | ZOce134       | OCEANA    | Pacific Ocean
+| 753   | ZOce124       | OCEANA    | Pacific Ocean
+| 754   | ZdBeTl        | DELBE     | Del Perro Beach
+| 755   | ZdBeTn        | DELBE     | Del Perro Beach
+| 756   | ZOce129       | OCEANA    | Pacific Ocean
+| 757   | ZdBeTm        | DELBE     | Del Perro Beach
+| 758   | ZdBeTj        | DELBE     | Del Perro Beach
+| 759   | ZdBeTh        | DELBE     | Del Perro Beach
+| 760   | ZOce123       | OCEANA    | Pacific Ocean
+| 761   | ZdBeTf        | DELBE     | Del Perro Beach
+| 762   | ZdBeTe        | DELBE     | Del Perro Beach
+| 763   | ZdBeTg        | DELBE     | Del Perro Beach
+| 764   | PB_Bem        | PBLUFF    | Pacific Bluffs
+| 765   | ZdBeTa        | DELBE     | Del Perro Beach
+| 766   | ZdBeTb        | DELBE     | Del Perro Beach
+| 767   | PB_BeI        | PBLUFF    | Pacific Bluffs
+| 768   | PB_BeJ        | PBLUFF    | Pacific Bluffs
+| 769   | PB_BeL        | PBLUFF    | Pacific Bluffs
+| 770   | PB_BeK        | PBLUFF    | Pacific Bluffs
+| 771   | ZdBeTc        | DELBE     | Del Perro Beach
+| 772   | ZdBeTd        | DELBE     | Del Perro Beach
+| 773   | ZOce150       | OCEANA    | Pacific Ocean
+| 774   | ZOce14        | OCEANA    | Pacific Ocean
+| 775   | ZOce135       | OCEANA    | Pacific Ocean
+| 776   | ZOce136       | PBLUFF    | Pacific Bluffs
+| 777   | ZOce137       | PBLUFF    | Pacific Bluffs
+| 778   | ZOce138       | OCEANA    | Pacific Ocean
+| 779   | ZOce139       | OCEANA    | Pacific Ocean
+| 780   | ZOce140       | OCEANA    | Pacific Ocean
+| 781   | ZOce141       | OCEANA    | Pacific Ocean
+| 782   | ZOce143       | OCEANA    | Pacific Ocean
+| 783   | ZOce142       | OCEANA    | Pacific Ocean
+| 784   | ZOce144       | OCEANA    | Pacific Ocean
+| 785   | ZOce145       | OCEANA    | Pacific Ocean
+| 786   | ZOce146       | OCEANA    | Pacific Ocean
+| 787   | ZOce147       | OCEANA    | Pacific Ocean
+| 788   | ZOce148       | OCEANA    | Pacific Ocean
+| 789   | ZOce149       | OCEANA    | Pacific Ocean
+| 790   | CIDE142       | NCHU      | North Chumash
+| 791   | Cide143       | CANNY     | Raton Canyon
+| 792   | Cide144       | CANNY     | Raton Canyon
+| 793   | zdBeTi        | DELBE     | Del Perro Beach
+| 794   | zdbeTo        | OCEANA    | Pacific Ocean
+| 795   | zdBeTp        | DELBE     | Del Perro Beach
+| 796   | zdBeTq        | DELBE     | Del Perro Beach
+| 797   | Cide145       | NCHU      | North Chumash
+| 798   | Z_DTWN1       | DOWNT     | Downtown
+| 799   | ZOce190       | OCEANA    | Pacific Ocean
+| 800   | ZOce188       | OCEANA    | Pacific Ocean
+| 801   | ZOce186       | OCEANA    | Pacific Ocean
+| 802   | ZOce187       | OCEANA    | Pacific Ocean
+| 803   | ZOce189       | OCEANA    | Pacific Ocean
+| 804   | ZOce185       | OCEANA    | Pacific Ocean
+| 805   | ZOce184       | OCEANA    | Pacific Ocean
+| 806   | ZOce183       | OCEANA    | Pacific Ocean
+| 807   | ZOce182       | OCEANA    | Pacific Ocean
+| 808   | ZOce178       | OCEANA    | Pacific Ocean
+| 809   | ZOce181       | OCEANA    | Pacific Ocean
+| 810   | ZOce180       | OCEANA    | Pacific Ocean
+| 811   | Cide172       | PALHIGH   | Palomino Highlands
+| 812   | Cide173       | PALHIGH   | Palomino Highlands
+| 813   | Cide182       | PALHIGH   | Palomino Highlands
+| 814   | Cide175       | PALHIGH   | Palomino Highlands
+| 815   | Cide174       | PALHIGH   | Palomino Highlands
+| 816   | Cide177       | PALHIGH   | Palomino Highlands
+| 817   | Cide178       | PALHIGH   | Palomino Highlands
+| 818   | Cide179       | PALHIGH   | Palomino Highlands
+| 819   | Cide180       | PALHIGH   | Palomino Highlands
+| 820   | Cide181       | PALHIGH   | Palomino Highlands
+| 821   | Cide176       | PALHIGH   | Palomino Highlands
+| 822   | ZOce177       | OCEANA    | Pacific Ocean
+| 823   | ZOce179       | OCEANA    | Pacific Ocean
+| 824   | ZOce191       | OCEANA    | Pacific Ocean
+| 825   | Cide183       | PALHIGH   | Palomino Highlands
+| 826   | Cide184       | PALHIGH   | Palomino Highlands
+| 827   | Cide187       | PALHIGH   | Palomino Highlands
+| 828   | Cide191       | PALHIGH   | Palomino Highlands
+| 829   | Cide192       | PALHIGH   | Palomino Highlands
+| 830   | Cide188       | PALHIGH   | Palomino Highlands
+| 831   | Cide186       | PALHIGH   | Palomino Highlands
+| 832   | Cide185       | PALHIGH   | Palomino Highlands
+| 833   | Cide190       | PALHIGH   | Palomino Highlands
+| 834   | ZOce168       | OCEANA    | Pacific Ocean
+| 835   | ZOce167       | OCEANA    | Pacific Ocean
+| 836   | ZOce164       | OCEANA    | Pacific Ocean
+| 837   | ZOce162       | OCEANA    | Pacific Ocean
+| 838   | ZOce160       | OCEANA    | Pacific Ocean
+| 839   | ZOce155       | OCEANA    | Pacific Ocean
+| 840   | ZOce153       | OCEANA    | Pacific Ocean
+| 841   | ZOce151       | OCEANA    | Pacific Ocean
+| 842   | ZOce152       | OCEANA    | Pacific Ocean
+| 842   | ZOce152       | OCEANA    | Pacific Ocean
+| 844   | ZOce154       | OCEANA    | Pacific Ocean
+| 845   | ZOce157       | OCEANA    | Pacific Ocean
+| 846   | ZOce156       | OCEANA    | Pacific Ocean
+| 847   | ZOce158       | OCEANA    | Pacific Ocean
+| 848   | ZOce176       | OCEANA    | Pacific Ocean
+| 849   | ZOce175       | OCEANA    | Pacific Ocean
+| 850   | ZOce174       | OCEANA    | Pacific Ocean
+| 851   | ZOce173       | OCEANA    | Pacific Ocean
+| 852   | ZOce172       | OCEANA    | Pacific Ocean
+| 853   | ZOce171       | OCEANA    | Pacific Ocean
+| 854   | ZOce170       | OCEANA    | Pacific Ocean
+| 855   | ZOce169       | OCEANA    | Pacific Ocean
+| 856   | ZOce166       | OCEANA    | Pacific Ocean
+| 857   | ZOce165       | OCEANA    | Pacific Ocean
+| 858   | ZOce163       | OCEANA    | Pacific Ocean
+| 859   | ZOce159       | OCEANA    | Pacific Ocean
+| 860   | ZOce214       | OCEANA    | Pacific Ocean
+| 861   | ZOce161       | OCEANA    | Pacific Ocean
+| 862   | ELBur1        | EBURO     | El Burro Heights
+| 863   | ELBur2        | EBURO     | El Burro Heights
+| 864   | ELBur3        | EBURO     | El Burro Heights
+| 865   | ELBur4        | EBURO     | El Burro Heights
+| 866   | ELBur5        | EBURO     | El Burro Heights
+| 867   | ZOce192       | OCEANA    | Pacific Ocean
+| 868   | ZOce193       | OCEANA    | Pacific Ocean
+| 869   | ZOce195       | OCEANA    | Pacific Ocean
+| 870   | ZOce201       | OCEANA    | Pacific Ocean
+| 871   | ZOce202       | OCEANA    | Pacific Ocean
+| 872   | ZOce208       | OCEANA    | Pacific Ocean
+| 873   | ZOce207       | OCEANA    | Pacific Ocean
+| 874   | ZOce209       | OCEANA    | Pacific Ocean
+| 875   | ZOce211       | OCEANA    | Pacific Ocean
+| 876   | ZOce210       | OCEANA    | Pacific Ocean
+| 877   | ZOce212       | OCEANA    | Pacific Ocean
+| 878   | ZOce213       | OCEANA    | Pacific Ocean
+| 879   | Cide150       | TATAMO    | Tataviam Mountains
+| 880   | Cide149       | TATAMO    | Tataviam Mountains
+| 881   | Cide205       | PALHIGH   | Palomino Highlands
+| 882   | Cide204       | PALHIGH   | Palomino Highlands
+| 883   | Cide203       | PALHIGH   | Palomino Highlands
+| 884   | Cide202       | PALHIGH   | Palomino Highlands
+| 885   | Cide201       | PALHIGH   | Palomino Highlands
+| 886   | Cide200       | PALHIGH   | Palomino Highlands
+| 887   | Cide199       | PALHIGH   | Palomino Highlands
+| 888   | Cide198       | PALHIGH   | Palomino Highlands
+| 889   | Cide197       | PALHIGH   | Palomino Highlands
+| 890   | Cide196       | PALHIGH   | Palomino Highlands
+| 891   | Cide195       | PALHIGH   | Palomino Highlands
+| 892   | Cide194       | PALHIGH   | Palomino Highlands
+| 893   | Cide193       | PALHIGH   | Palomino Highlands
+| 894   | Cide148       | TATAMO    | Tataviam Mountains
+| 895   | Cide147       | TATAMO    | Tataviam Mountains
+| 896   | Cide146       | PALHIGH   | Palomino Highlands
+| 897   | Cide171       | PALHIGH   | Palomino Highlands
+| 898   | Cide170       | PALHIGH   | Palomino Highlands
+| 899   | Cide165       | PALHIGH   | Palomino Highlands
+| 900   | Cide164       | PALHIGH   | Palomino Highlands
+| 901   | Cide169       | PALHIGH   | Palomino Highlands
+| 902   | Cide163       | PALHIGH   | Palomino Highlands
+| 903   | Cide166       | PALHIGH   | Palomino Highlands
+| 904   | Cide162       | PALHIGH   | Palomino Highlands
+| 905   | Cide161       | PALHIGH   | Palomino Highlands
+| 906   | Cide160       | PALHIGH   | Palomino Highlands
+| 907   | Cide159       | PALHIGH   | Palomino Highlands
+| 908   | Cide157       | TATAMO    | Tataviam Mountains
+| 909   | Cide156       | TATAMO    | Tataviam Mountains
+| 910   | Cide155       | TATAMO    | Tataviam Mountains
+| 911   | Cide154       | TATAMO    | Tataviam Mountains
+| 912   | Cide153       | TATAMO    | Tataviam Mountains
+| 913   | ZOce286       | OCEANA    | Pacific Ocean
+| 914   | Cide151       | TATAMO    | Tataviam Mountains
+| 915   | ZOce282       | OCEANA    | Pacific Ocean
+| 916   | ZOce204       | OCEANA    | Pacific Ocean
+| 917   | ZOce205       | OCEANA    | Pacific Ocean
+| 918   | ZOce200       | OCEANA    | Pacific Ocean
+| 919   | ZOce203       | OCEANA    | Pacific Ocean
+| 920   | ZOce196       | OCEANA    | Pacific Ocean
+| 921   | ZOce194       | OCEANA    | Pacific Ocean
+| 922   | ZOce198       | OCEANA    | Pacific Ocean
+| 923   | Cide167       | PALHIGH   | Palomino Highlands
+| 924   | ZOce197       | OCEANA    | Pacific Ocean
+| 925   | Cide168       | PALHIGH   | Palomino Highlands
+| 926   | ZOce199       | OCEANA    | Pacific Ocean
+| 927   | Cide189       | PALHIGH   | Palomino Highlands
+| 928   | Cide131       | TATAMO    | Tataviam Mountains
+| 929   | CIDE84        | HUMLAB    | Humane Labs and Research
+| 930   | SanChi7       | SANCHIA   | San Chianski Mountain Range
+| 931   | SanChi6       | SANCHIA   | San Chianski Mountain Range
+| 932   | SanChi4       | SANCHIA   | San Chianski Mountain Range
+| 933   | SanChi3       | SANCHIA   | San Chianski Mountain Range
+| 934   | SanChi5       | SANCHIA   | San Chianski Mountain Range
+| 935   | SanChi1       | SANCHIA   | San Chianski Mountain Range
+| 936   | SanChi2       | SANCHIA   | San Chianski Mountain Range
+| 937   | CalaB         | CALAFB    | Calafia Bridge
+| 938   | Cide139       | GALFISH   | Galilee
+| 939   | Cide138       | GALFISH   | Galilee
+| 940   | Cide63        | GALFISH   | Galilee
+| 941   | NOSE1         | NOOSE     | N.O.O.S.E
+| 942   | NOSE2         | NOOSE     | N.O.O.S.E
+| 943   | ZOce215       | PBLUFF    | Pacific Bluffs
+| 944   | C_Cre2        | CCREAK    | Cassidy Creek
+| 945   | C_Cre3        | CCREAK    | Cassidy Creek
+| 946   | C_Cre1        | CCREAK    | Cassidy Creek
+| 947   | C_Cre5        | CCREAK    | Cassidy Creek
+| 948   | Z_CHi1        | CHIL      | Vinewood Hills
+| 949   | WetLD         | LAGO      | Lago Zancudo
+| 950   | WetLD5        | LAGO      | Lago Zancudo
+| 951   | WetLD3        | LAGO      | Lago Zancudo
+| 952   | WetLD6        | LAGO      | Lago Zancudo
+| 953   | TongV         | TONGVAV   | Tongva Valley
+| 954   | BanH1         | BHAMCA    | Banham Canyon
+| 955   | BanH2         | BHAMCA    | Banham Canyon
+| 956   | CIDE140       | BANHAMC   | Banham Canyon Dr
+| 957   | CIDE141       | BANHAMC   | Banham Canyon Dr
+| 958   | TonH1         | TONGVAH   | Tongva Hills
+| 959   | TonH2         | TONGVAH   | Tongva Hills
+| 960   | TonH3         | TONGVAH   | Tongva Hills
+| 961   | TonH4         | TONGVAH   | Tongva Hills
+| 962   | Cide62        | GREATC    | Great Chaparral
+| 963   | Cide59        | CHIL      | Vinewood Hills
+| 964   | Cide60        | CHIL      | Vinewood Hills
+| 965   | Cide65        | DESRT     | Grand Senora Desert
+| 966   | Cide64        | GREATC    | Great Chaparral
+| 967   | WetLD7        | LAGO      | Lago Zancudo
+| 968   | LARes         | LACT      | Land Act Reservoir
+| 969   | LADam         | LDAM      | Land Act Dam
+| 970   | Army5         | ARMYB     | Fort Zancudo
+| 971   | WetLD8        | LAGO      | Lago Zancudo
+| 972   | WetLD9        | LAGO      | Lago Zancudo
+| 973   | WetLD0        | LAGO      | Lago Zancudo
+| 974   | ZOce217       | LAGO      | Lago Zancudo
+| 975   | Frw54         | PALFOR    | Paleto Forest
+| 976   | ZPBay8        | PALFOR    | Paleto Forest
+| 977   | ZOce12        | OCEANA    | Pacific Ocean
+| 978   | PalCo1        | PALCOV    | Paleto Cove
+| 979   | PalCo2        | PALCOV    | Paleto Cove
+| 980   | PalCo3        | PALCOV    | Paleto Cove
+| 981   | PalCo4        | PALCOV    | Paleto Cove
+| 982   | PalCo5        | PALCOV    | Paleto Cove
+| 983   | PalCo6        | PALCOV    | Paleto Cove
+| 984   | ZPBay0        | PALETO    | Paleto Bay
+| 985   | Z_RHL12       | ROCKF     | Rockford Hills
+| 986   | Z_MVS6        | MOVIE     | Richards Majestic
+| 987   | ZOce222       | OCEANA    | Pacific Ocean
+| 988   | ZOce221       | OCEANA    | Pacific Ocean
+| 989   | ZOce220       | OCEANA    | Pacific Ocean
+| 990   | ZOce224       | OCEANA    | Pacific Ocean
+| 991   | ZOce219       | OCEANA    | Pacific Ocean
+| 992   | ZOce223       | OCEANA    | Pacific Ocean
+| 993   | ZOce225       | OCEANA    | Pacific Ocean
+| 994   | ZOce226       | OCEANA    | Pacific Ocean
+| 995   | Cide206       | GREATC    | Great Chaparral
+| 996   | Cide207       | DESRT     | Grand Senora Desert
+| 997   | Legs2         | LEGSQU    | Legion Square
+| 998   | Legs1         | LEGSQU    | Legion Square
+| 999   | Legs3         | LEGSQU    | Legion Square
+| 1000  | Z_EVi5        | EAST_V    | East Vinewood
+| 1001  | ZOce239       | OCEANA    | Pacific Ocean
+| 1002  | ZOce240       | OCEANA    | Pacific Ocean
+| 1003  | ZOce241       | OCEANA    | Pacific Ocean
+| 1004  | ZOce242       | OCEANA    | Pacific Ocean
+| 1005  | ZOce243       | OCEANA    | Pacific Ocean
+| 1006  | ZOce237       | OCEANA    | Pacific Ocean
+| 1007  | ZOce238       | OCEANA    | Pacific Ocean
+| 1008  | ZOce236       | OCEANA    | Pacific Ocean
+| 1009  | ZOce235       | OCEANA    | Pacific Ocean
+| 1010  | ZOce232       | OCEANA    | Pacific Ocean
+| 1011  | ZOce233       | OCEANA    | Pacific Ocean
+| 1012  | ZOce234       | OCEANA    | Pacific Ocean
+| 1013  | ZOce230       | OCEANA    | Pacific Ocean
+| 1014  | ZOce228       | OCEANA    | Pacific Ocean
+| 1015  | ZOce229       | OCEANA    | Pacific Ocean
+| 1016  | ZOce231       | OCEANA    | Pacific Ocean
+| 1017  | ZElys2        | ELYSIAN   | Elysian Island
+| 1018  | ZOce246       | OCEANA    | Pacific Ocean
+| 1019  | ZOce245       | OCEANA    | Pacific Ocean
+| 1020  | ZOce244       | OCEANA    | Pacific Ocean
+| 1021  | ZPoRT4        | ELYSIAN   | Elysian Island
+| 1022  | ZBann         | BANNING   | Banning
+| 1023  | ZdBeQ         | DELBE     | Del Perro Beach
+| 1024  | ZdBeL         | DELBE     | Del Perro Beach
+| 1025  | ZPBayA        | PALFOR    | Paleto Forest
+| 1026  | ZPBayN        | PALETO    | Paleto Bay
+| 1027  | ZPBayP        | PALETO    | Paleto Bay
+| 1028  | ZPBayO        | PALETO    | Paleto Bay
+| 1029  | ZPBayG        | PALETO    | Paleto Bay
+| 1030  | ZPBayE        | PALETO    | Paleto Bay
+| 1031  | ZPBayC        | PALETO    | Paleto Bay
+| 1032  | ZPBayB        | PALETO    | Paleto Bay
+| 1033  | ZOce1         | OCEANA    | Pacific Ocean
+| 1034  | ZOce247       | OCEANA    | Pacific Ocean
+| 1035  | ZOce250       | OCEANA    | Pacific Ocean
+| 1036  | ZOce248       | OCEANA    | Pacific Ocean
+| 1037  | ZOce249       | OCEANA    | Pacific Ocean
+| 1038  | ZOce257       | OCEANA    | Pacific Ocean
+| 1039  | ZOce260       | OCEANA    | Pacific Ocean
+| 1040  | ZOce269       | OCEANA    | Pacific Ocean
+| 1041  | ZOce268       | OCEANA    | Pacific Ocean
+| 1042  | ZOce267       | OCEANA    | Pacific Ocean
+| 1043  | ZOce266       | OCEANA    | Pacific Ocean
+| 1044  | ZOce265       | OCEANA    | Pacific Ocean
+| 1045  | ZOce264       | OCEANA    | Pacific Ocean
+| 1046  | ZOce263       | OCEANA    | Pacific Ocean
+| 1047  | ZOce272       | OCEANA    | Pacific Ocean
+| 1048  | ZOce274       | OCEANA    | Pacific Ocean
+| 1049  | ZOce273       | OCEANA    | Pacific Ocean
+| 1050  | Cide208       | MTGORDO   | Mount Gordo
+| 1051  | Z_CHi2        | CHIL      | Vinewood Hills
+| 1052  | Z_CHi5        | CHIL      | Vinewood Hills
+| 1053  | ZOce58        | SANCHIA   | San Chianski Mountain Range
+| 1054  | ZOce280       | OCEANA    | Pacific Ocean
+| 1055  | ZOce275       | OCEANA    | Pacific Ocean
+| 1056  | ZOce276       | OCEANA    | Pacific Ocean
+| 1057  | ZOce277       | OCEANA    | Pacific Ocean
+| 1058  | ZOce279       | OCEANA    | Pacific Ocean
+| 1059  | Cide112       | SANCHIA   | San Chianski Mountain Range
+| 1060  | Cide215       | SANCHIA   | San Chianski Mountain Range
+| 1061  | Cide214       | SANCHIA   | San Chianski Mountain Range
+| 1062  | Cide211       | SANCHIA   | San Chianski Mountain Range
+| 1063  | Cide212       | SANCHIA   | San Chianski Mountain Range
+| 1064  | Cide209       | SANCHIA   | San Chianski Mountain Range
+| 1065  | Cide210       | SANCHIA   | San Chianski Mountain Range
+| 1066  | ZOce278       | OCEANA    | Pacific Ocean
+| 1067  | Cide213       | SANCHIA   | San Chianski Mountain Range
+| 1068  | SanChi8       | SANCHIA   | San Chianski Mountain Range
+| 1069  | ZOce281       | OCEANA    | Pacific Ocean
+| 1070  | Kapow1        | PALMPOW   | Palmer-Taylor Power Station
+| 1071  | Kapow2        | PALMPOW   | Palmer-Taylor Power Station
+| 1072  | CIDE158       | PALHIGH   | Palomino Highlands
+| 1073  | Cide216       | TATAMO    | Tataviam Mountains
+| 1074  | Cide217       | TATAMO    | Tataviam Mountains
+| 1075  | ZOce285       | PALHIGH   | Palomino Highlands
+| 1076  | Zoce26        | OCEANA    | Pacific Ocean
+| 1077  | ZOce283       | OCEANA    | Pacific Ocean
+| 1078  | ZOce284       | OCEANA    | Pacific Ocean
+| 1079  | ZOce287       | OCEANA    | Pacific Ocean
+| 1080  | ZOce288       | OCEANA    | Pacific Ocean
+| 1081  | ZPBayM        | PALETO    | Paleto Bay
+| 1082  | ZPBayF        | PALETO    | Paleto Bay
+| 1083  | ZPBayD        | PALETO    | Paleto Bay
+| 1084  | ZPBayU        | PALETO    | Paleto Bay
+| 1085  | ZPBayV        | PALETO    | Paleto Bay
+| 1086  | ZPBayX        | PALETO    | Paleto Bay
+| 1087  | ZPBayY        | PALETO    | Paleto Bay
+| 1088  | ZPBayL        | PALETO    | Paleto Bay
+| 1089  | ZPBayI        | PALETO    | Paleto Bay
+| 1090  | ZOce253       | OCEANA    | Pacific Ocean
+| 1091  | ZOce258       | OCEANA    | Pacific Ocean
+| 1092  | ZOce255       | OCEANA    | Pacific Ocean
+| 1093  | ZPBayJ        | PALETO    | Paleto Bay
+| 1094  | ZPBayK        | PALETO    | Paleto Bay
+| 1095  | ZOce44        | OCEANA    | Pacific Ocean
+| 1096  | FXT03         | PALFOR    | Paleto Forest
+| 1097  | FXT02         | PALFOR    | Paleto Forest
+| 1098  | FXT01         | PALFOR    | Paleto Forest
+| 1099  | FXT04         | PALFOR    | Paleto Forest
+| 1100  | FXT10         | PALFOR    | Paleto Forest
+| 1101  | FXT05         | PALFOR    | Paleto Forest
+| 1102  | FXT08         | PALFOR    | Paleto Forest
+| 1103  | FXT06         | PALFOR    | Paleto Forest
+| 1104  | FXT14         | PALFOR    | Paleto Forest
+| 1105  | FXT13         | PALFOR    | Paleto Forest
+| 1106  | FXT11         | PALETO    | Paleto Bay
+| 1107  | FXT07         | PALFOR    | Paleto Forest
+| 1108  | FXT16         | PALETO    | Paleto Bay
+| 1109  | FXT17         | MTCHIL    | Mount Chiliad
+| 1110  | FXT12         | PALETO    | Paleto Bay
+| 1111  | FXT22         | PALETO    | Paleto Bay
+| 1112  | FXT09         | PALETO    | Paleto Bay
+| 1113  | FXT15         | PALETO    | Paleto Bay
+| 1114  | FXT18         | PALETO    | Paleto Bay
+| 1115  | FXT27         | MTCHIL    | Mount Chiliad
+| 1116  | FXT24         | MTCHIL    | Mount Chiliad
+| 1117  | FXT19         | MTCHIL    | Mount Chiliad
+| 1118  | FXT28         | MTCHIL    | Mount Chiliad
+| 1119  | FXT20         | MTCHIL    | Mount Chiliad
+| 1120  | FXT26         | MTCHIL    | Mount Chiliad
+| 1121  | FXT23         | MTCHIL    | Mount Chiliad
+| 1122  | FXT25         | MTCHIL    | Mount Chiliad
+| 1123  | FXT21         | MTCHIL    | Mount Chiliad
+| 1124  | VFX29         | LAGO      | Lago Zancudo
+| 1125  | FXT108        | MTCHIL    | Mount Chiliad
+| 1126  | FXT116        | MTCHIL    | Mount Chiliad
+| 1127  | FXT117        | MTCHIL    | Mount Chiliad
+| 1128  | FXT118        | GRAPES    | Grapeseed
+| 1129  | FXT98         | MTCHIL    | Mount Chiliad
+| 1130  | FXT100        | MTCHIL    | Mount Chiliad
+| 1131  | FXT103        | MTCHIL    | Mount Chiliad
+| 1132  | FXT105        | MTCHIL    | Mount Chiliad
+| 1133  | FXT101        | MTCHIL    | Mount Chiliad
+| 1134  | FXT102        | MTCHIL    | Mount Chiliad
+| 1135  | FXT99         | MTCHIL    | Mount Chiliad
+| 1136  | FXT104        | MTCHIL    | Mount Chiliad
+| 1137  | FXT106        | ALAMO     | Alamo Sea
+| 1138  | FXT112        | MTCHIL    | Mount Chiliad
+| 1139  | FXT115        | MTCHIL    | Mount Chiliad
+| 1140  | FXT109        | MTCHIL    | Mount Chiliad
+| 1141  | FXT113        | MTCHIL    | Mount Chiliad
+| 1142  | FXT111        | MTCHIL    | Mount Chiliad
+| 1143  | FXT110        | MTCHIL    | Mount Chiliad
+| 1144  | FXT114        | MTCHIL    | Mount Chiliad
+| 1145  | FXT90         | MTCHIL    | Mount Chiliad
+| 1146  | FXT94         | MTCHIL    | Mount Chiliad
+| 1147  | FXT93         | MTCHIL    | Mount Chiliad
+| 1148  | FXT92         | MTCHIL    | Mount Chiliad
+| 1149  | FXT96         | MTCHIL    | Mount Chiliad
+| 1150  | FXT97         | MTCHIL    | Mount Chiliad
+| 1151  | FXT95         | MTCHIL    | Mount Chiliad
+| 1152  | FXT91         | MTCHIL    | Mount Chiliad
+| 1153  | FXT107        | ALAMO     | Alamo Sea
+| 1154  | FXT119        | CMSW      | Chiliad Mountain State Wilderness
+| 1155  | FXT120        | CMSW      | Chiliad Mountain State Wilderness
+| 1156  | FXT121        | CMSW      | Chiliad Mountain State Wilderness
+| 1157  | FXT122        | CMSW      | Chiliad Mountain State Wilderness
+| 1158  | FXT127        | CMSW      | Chiliad Mountain State Wilderness
+| 1159  | FXT123        | CMSW      | Chiliad Mountain State Wilderness
+| 1160  | FXT124        | CMSW      | Chiliad Mountain State Wilderness
+| 1161  | FXT128        | CMSW      | Chiliad Mountain State Wilderness
+| 1162  | FXT130        | CMSW      | Chiliad Mountain State Wilderness
+| 1163  | FXT129        | CMSW      | Chiliad Mountain State Wilderness
+| 1164  | FXT131        | CMSW      | Chiliad Mountain State Wilderness
+| 1165  | FXT143        | CMSW      | Chiliad Mountain State Wilderness
+| 1166  | FXT142        | CMSW      | Chiliad Mountain State Wilderness
+| 1167  | FXT132        | CMSW      | Chiliad Mountain State Wilderness
+| 1168  | FXT133        | CMSW      | Chiliad Mountain State Wilderness
+| 1169  | FXT135        | CMSW      | Chiliad Mountain State Wilderness
+| 1170  | FXT136        | CMSW      | Chiliad Mountain State Wilderness
+| 1171  | FXT137        | CMSW      | Chiliad Mountain State Wilderness
+| 1172  | FXT138        | CMSW      | Chiliad Mountain State Wilderness
+| 1173  | FXT139        | CMSW      | Chiliad Mountain State Wilderness
+| 1174  | FXT140        | CMSW      | Chiliad Mountain State Wilderness
+| 1175  | FXT134        | CMSW      | Chiliad Mountain State Wilderness
+| 1176  | FXT125        | CMSW      | Chiliad Mountain State Wilderness
+| 1177  | FXT126        | CMSW      | Chiliad Mountain State Wilderness
+| 1178  | RedTRK        | RTRAK     | Redwood Lights Track
+| 1179  | C_Cre4        | CCREAK    | Cassidy Creek
+| 1180  | FXT144        | LAGO      | Lago Zancudo
+| 1181  | FXT89         | LAGO      | Lago Zancudo
+| 1182  | FXT88         | LAGO      | Lago Zancudo
+| 1183  | FXT87         | LAGO      | Lago Zancudo
+| 1184  | FXT86         | LAGO      | Lago Zancudo
+| 1185  | FXT85         | LAGO      | Lago Zancudo
+| 1186  | FXT84         | LAGO      | Lago Zancudo
+| 1187  | FXT83         | LAGO      | Lago Zancudo
+| 1188  | FXT82         | LAGO      | Lago Zancudo
+| 1189  | FXT81         | LAGO      | Lago Zancudo
+| 1190  | FXT80         | LAGO      | Lago Zancudo
+| 1191  | FXT79         | LAGO      | Lago Zancudo
+| 1192  | FXT78         | LAGO      | Lago Zancudo
+| 1193  | FXT77         | LAGO      | Lago Zancudo
+| 1194  | FXT76         | LAGO      | Lago Zancudo
+| 1195  | FXT75         | LAGO      | Lago Zancudo
+| 1196  | FXT69         | LAGO      | Lago Zancudo
+| 1197  | FXT67         | LAGO      | Lago Zancudo
+| 1198  | FXT66         | LAGO      | Lago Zancudo
+| 1199  | FXT65         | LAGO      | Lago Zancudo
+| 1200  | FXT64         | ZANCUDO   | Zancudo River
+| 1201  | FXT63         | ZANCUDO   | Zancudo River
+| 1202  | FXT62         | ZANCUDO   | Zancudo River
+| 1203  | FXT61         | ZANCUDO   | Zancudo River
+| 1204  | FXT60         | ZANCUDO   | Zancudo River
+| 1205  | FXT59         | LAGO      | Lago Zancudo
+| 1206  | FXT58         | LAGO      | Lago Zancudo
+| 1207  | FXT57         | LAGO      | Lago Zancudo
+| 1208  | FXT56         | LAGO      | Lago Zancudo
+| 1209  | FXT55         | LAGO      | Lago Zancudo
+| 1210  | FXT54         | LAGO      | Lago Zancudo
+| 1211  | FXT53         | LAGO      | Lago Zancudo
+| 1212  | FXT52         | LAGO      | Lago Zancudo
+| 1213  | FXT51         | LAGO      | Lago Zancudo
+| 1214  | FXT50         | LAGO      | Lago Zancudo
+| 1215  | FXT49         | LAGO      | Lago Zancudo
+| 1216  | FXT48         | LAGO      | Lago Zancudo
+| 1217  | FXT47         | LAGO      | Lago Zancudo
+| 1218  | FXT46         | LAGO      | Lago Zancudo
+| 1219  | FXT45         | LAGO      | Lago Zancudo
+| 1220  | FXT44         | LAGO      | Lago Zancudo
+| 1221  | FXT41         | LAGO      | Lago Zancudo
+| 1222  | FXT40         | LAGO      | Lago Zancudo
+| 1223  | FXT39         | LAGO      | Lago Zancudo
+| 1224  | FXT38         | LAGO      | Lago Zancudo
+| 1225  | FXT37         | LAGO      | Lago Zancudo
+| 1226  | FXT36         | LAGO      | Lago Zancudo
+| 1227  | FXT35         | LAGO      | Lago Zancudo
+| 1228  | FXT34         | LAGO      | Lago Zancudo
+| 1229  | FXT32         | LAGO      | Lago Zancudo
+| 1230  | FXT31         | LAGO      | Lago Zancudo
+| 1231  | FXT30         | LAGO      | Lago Zancudo
+| 1232  | FXT29         | LAGO      | Lago Zancudo
+| 1233  | LMis051       | SLAB      | Stab City
+| 1234  | LMis050       | SLAB      | Stab City
+| 1235  | LMis049       | SLAB      | Stab City
+| 1236  | LMis048       | SLAB      | Stab City
+| 1237  | LMis047       | SLAB      | Stab City
+| 1238  | LMis046       | ALAMO     | Alamo Sea
+| 1239  | LMis045       | ALAMO     | Alamo Sea
+| 1240  | LMis044       | ALAMO     | Alamo Sea
+| 1241  | LMis043       | ALAMO     | Alamo Sea
+| 1242  | LMis042       | ALAMO     | Alamo Sea
+| 1243  | LMis041       | ALAMO     | Alamo Sea
+| 1244  | LMis040       | ALAMO     | Alamo Sea
+| 1245  | LMis039       | ALAMO     | Alamo Sea
+| 1246  | LMis038       | ALAMO     | Alamo Sea
+| 1247  | LMis037       | ALAMO     | Alamo Sea
+| 1248  | LMis036       | ALAMO     | Alamo Sea
+| 1249  | LMis035       | ALAMO     | Alamo Sea
+| 1250  | LMis034       | ALAMO     | Alamo Sea
+| 1251  | LMis033       | ALAMO     | Alamo Sea
+| 1252  | LMis032       | ALAMO     | Alamo Sea
+| 1253  | LMis031       | ALAMO     | Alamo Sea
+| 1254  | LMis030       | ALAMO     | Alamo Sea
+| 1255  | LMis029       | ALAMO     | Alamo Sea
+| 1256  | LMis028       | ALAMO     | Alamo Sea
+| 1257  | LMis027       | ALAMO     | Alamo Sea
+| 1258  | LMis026       | ALAMO     | Alamo Sea
+| 1259  | LMis025       | SANDY     | Sandy Shores
+| 1260  | LMis024       | SANDY     | Sandy Shores
+| 1261  | LMis023       | SANDY     | Sandy Shores
+| 1262  | LMis022       | SANDY     | Sandy Shores
+| 1263  | LMis021       | SANDY     | Sandy Shores
+| 1264  | LMis020       | SANDY     | Sandy Shores
+| 1265  | LMis019       | SANDY     | Sandy Shores
+| 1266  | LMis018       | SANDY     | Sandy Shores
+| 1267  | LMis017       | SANDY     | Sandy Shores
+| 1268  | LMis016       | SANDY     | Sandy Shores
+| 1269  | LMis015       | SANDY     | Sandy Shores
+| 1270  | LMis014       | SANDY     | Sandy Shores
+| 1271  | LMis013       | SANDY     | Sandy Shores
+| 1272  | LMis012       | SANDY     | Sandy Shores
+| 1273  | LMis011       | SANDY     | Sandy Shores
+| 1274  | LMis010       | SANDY     | Sandy Shores
+| 1275  | LMis009       | SANDY     | Sandy Shores
+| 1276  | LMis008       | ALAMO     | Alamo Sea
+| 1277  | LMis007       | ALAMO     | Alamo Sea
+| 1278  | LMis006       | ALAMO     | Alamo Sea
+| 1279  | LMis005       | ALAMO     | Alamo Sea
+| 1280  | LMis004       | ALAMO     | Alamo Sea
+| 1281  | LMis003       | ALAMO     | Alamo Sea
+| 1282  | LMis002       | ALAMO     | Alamo Sea
+| 1283  | LMis001       | ALAMO     | Alamo Sea
+| 1284  | CnWd4         | CANNY     | Raton Canyon
+| 1285  | CnWd3         | CANNY     | Raton Canyon
+| 1286  | CnWd1         | CANNY     | Raton Canyon
+| 1287  | CnWd2         | CANNY     | Raton Canyon
+| 1288  | CnWd6         | CANNY     | Raton Canyon
+| 1289  | CnWd5         | CANNY     | Raton Canyon
+| 1290  | CnWd7         | CANNY     | Raton Canyon
+| 1291  | CnWd0         | CCREAK    | Cassidy Creek
+| 1292  | CnWd9         | CANNY     | Raton Canyon
+| 1293  | CnWd8         | CANNY     | Raton Canyon
+| 1294  | CnWd10        | CANNY     | Raton Canyon
+| 1295  | CnWd11        | CANNY     | Raton Canyon
+| 1296  | RDust1        | CHIL      | Vinewood Hills
+| 1297  | RDust3        | CHIL      | Vinewood Hills
+| 1298  | RDust2        | CHIL      | Vinewood Hills
+| 1299  | RDust4        | CHIL      | Vinewood Hills
+| 1300  | RDust5        | CHIL      | Vinewood Hills
+| 1301  | RDust8        | CHIL      | Vinewood Hills
+| 1302  | RDust9        | CHIL      | Vinewood Hills
+| 1303  | RDust6        | CHIL      | Vinewood Hills
+| 1304  | RDust7        | CHIL      | Vinewood Hills
+| 1305  | RDust10       | CHIL      | Vinewood Hills
+| 1306  | RDust11       | CHIL      | Vinewood Hills
+| 1307  | DevHs1        | TONGVAH   | Tongva Hills
+| 1308  | DevHs2        | BHAMCA    | Banham Canyon
+| 1309  | CIDE61        | CHIL      | Vinewood Hills
+| 1310  | RDUST12       | CHIL      | Vinewood Hills
+| 1311  | RDUST13       | CHIL      | Vinewood Hills
+| 1312  | RDUST14       | CHIL      | Vinewood Hills
+| 1313  | RDUST16       | DESRT     | Grand Senora Desert
+| 1314  | RDUST15       | DESRT     | Grand Senora Desert
+| 1315  | ZnFly2        | MTCHIL    | Mount Chiliad
+| 1316  | ZnFly1        | PALFOR    | Paleto Forest
+| 1317  | ZnFly3        | CMSW      | Chiliad Mountain State Wilderness
+| 1318  | ZElys3        | ELYSIAN   | Elysian Island
+| 1319  | FXT106a       | ALAMO     | Alamo Sea
+| 1320  | FXT138a       | CMSW      | Chiliad Mountain State Wilderness
+| 1321  | IsHeist       | ISHEIST   | Cayo Perico Island


### PR DESCRIPTION
This PR adds a list of the GTAV Zones to the game references as requested by @technetium-cfx in https://github.com/citizenfx/natives/pull/1260#issuecomment-3195873069 and should be merged together with that linked PR.

Credit for creating this list goes towards @MichaelCoding25 who created this list and uploaded it as a gist to https://gist.githubusercontent.com/MichaelCoding25/11455d704d030630156c3e742ee13e5e/raw/4658c80275715cf11cf5340db3981fa810d781e9/gtavzoneslist.md. 

The list includes an integer ID from update\update.rpf\common\data\levels\gta5\popzone.ipl which is just the index of the listed zone, starting at 1. The zone name ID is what is used by some natives like GET_ZONE_FROM_NAME_ID, while other natives use the broader Zone Name like GET_NAME_OF_ZONE. Lastly the Zone Description is the humanly readable and commonly understandable name of the zone.