### PR TITLE
Update gamepad settings in profile settings documentation

### DIFF
--- a/content/docs/game-references/profile-settings.md
+++ b/content/docs/game-references/profile-settings.md
@@ -28,7 +28,7 @@ GTA V profile setting values can be obtained using this native: {{% native_link 
 |   `16` |                   |                                                 |
 |   `17` | Gamepad           | Allow Movement When Zoomed                      |
 |   `18` |                   |                                                 |
-|   `19` |                   |                                                 |
+|   `19` | Gamepad           | Sprint Mode (available in build 2944)           |
 |   `20` | Gamepad           | First person control type                       |
 |   `21` | Keyboard / Mouse  | Invert Mouse Flying                             |
 |   `22` | Keyboard / Mouse  | Invert Mouse Submarine                          |


### PR DESCRIPTION
Adds sprint mode to ID 19 to profile settings.
This option only appears in the settings -> gamepad menu on build 2944, but its value does persist in later versions.

0 = Tap to sprint
1 = Hold to sprint

Despite being a gamepad setting, it does affect usage on keyboard/mouse.