### PR TITLE
fix: grammar and casing in proxy-setup and console-commands

### DIFF
--- a/content/docs/client-manual/console-commands.md
+++ b/content/docs/client-manual/console-commands.md
@@ -133,7 +133,7 @@ An alias for `loadlevel`, see the [loadlevel](#loadlevel) command for details.
 
 ### list_aces
 <!-- TODO: probably needs a reference to an explanation for ACL stuff -->
-Lists all the aces (access control entries) in the console. It creates a list of the relationship between an principal
+Lists all the aces (access control entries) in the console. It creates a list of the relationship between a principal
 and object and if they're allowed or not allowed to use it. Example output:
 
 ```

--- a/content/docs/server-manual/proxy-setup.md
+++ b/content/docs/server-manual/proxy-setup.md
@@ -191,16 +191,16 @@ server {
 
 As you can see inside the configuration an `ssl_certificate` and `ssl_certificate_key` is required.
 
-The easiest way is to use an self signed certificates when you don't have a domain name associated with your server ip.
+The easiest way is to use self-signed certificates when you don't have a domain name associated with your server ip.
 When you have a domain already configured you can setup [Let's Encrypt](https://letsencrypt.org) to generate this for you.
 
-On Linux the easiest way to generate self signed certificates is using `openssl`.
+On Linux the easiest way to generate self-signed certificates is using `openssl`.
 ```
 sudo openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/ssl/private/nginx-selfsigned.key -out /etc/ssl/certs/nginx-selfsigned.crt
 ```
 
-For Windows a openssl Binary can be found at [Binaries](https://wiki.openssl.org/index.php/Binaries).
-Which works the same as the Linux Version.
+For Windows an openssl binary can be found at [Binaries](https://wiki.openssl.org/index.php/Binaries).
+Which works the same as the Linux version.
 ```
 openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout nginx-selfsigned.key -out nginx-selfsigned.crt
 ```


### PR DESCRIPTION
## Summary

Small grammar and casing fixes spotted while reading two pages:

**`content/docs/server-manual/proxy-setup.md`**
- "use an self signed certificates" → "use self-signed certificates" (incorrect article + missing hyphen)
- "generate self signed certificates" → "generate self-signed certificates" (missing hyphen on compound adjective)
- "a openssl Binary" → "an openssl binary" (article before vowel sound + common noun shouldn't be capitalized)
- "the Linux Version" → "the Linux version" (common noun shouldn't be capitalized)

**`content/docs/client-manual/console-commands.md`**
- "between an principal" → "between a principal" (article before consonant)

No content changes, purely spelling/grammar cleanup as permitted by the contribution guidelines.
