### PR TITLE
Fix Contributing href in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ If you encounter any dead links or issues, please report them on our [GitHub Iss
 
 ### Wanna Contribute? 🤝
 
-We love contributions! If you're interested in helping out, check out our [Contribution Guidelines](content/docs/contributing/contribution-guidelines/) to get started.
+We love contributions! If you're interested in helping out, check out our [Contribution Guidelines](content/docs/contributing/contribution-guidelines.md) to get started.
 
 [docs]: https://docs.fivem.net


### PR DESCRIPTION
Link for Wanna Contribute? 404s in main README.

Adding `.md` to the href so readers are directed to the Contribution Guidelines page.