### PR TITLE
Document strict mode state bags

### DIFF
--- a/content/docs/scripting-manual/networking/state-bags.md
+++ b/content/docs/scripting-manual/networking/state-bags.md
@@ -87,8 +87,7 @@ An example implementation method can be found in the following native documentat
 
 ## Policy
 
-Currently, the only policy limitation implemented is to filter _player_ state to be able to be written by the player and the server, _entity_ state to be written by the owning player and the server, and _global_ state to be able to be written by the server.
+By default  _player_ state can be able to be written by the player and the server, _entity_ state can be written by the owning player and the server, and _global_ state can be written by the server. 
 
-In the future, events and filter functionality may be added for further safeguarding of server-configured state.
-
+This behavior can be overriden by using the [sv_stateBagStrictMode](docs/server-manual/server-commands/#setr-sv_stateBagStrictMode-truefalse) server ConVar - with it set to `true` only the server can modify a state bag. 
 <!-- other ScRTs todo -->

--- a/content/docs/server-manual/server-commands.md
+++ b/content/docs/server-manual/server-commands.md
@@ -408,6 +408,15 @@ This is particularly useful when using custom proxy servers with `fileserver_add
 
 This is set to false by default.
 
+### `setr sv_stateBagStrictMode [true|false]`
+
+A console variable, introduced in server version 12739, used to enable or disable client-side modification of state bags by the network owner of a replicated entity.
+
+- false (Default): The network owner can modify the state of entities they own and the player state.
+- true: Only the server can modify the state of networked entities and the player state.
+
+Client-side (non-replicated) entities are not affected by this variable. If a client-side script attempts to modify a state bag on a replicated entity in strict mode, the following error will be displayed in the client console `StateBags can't be modified from the client, because the StateBag strict mode is enabled. Disable it using setr sv_stateBagStrictMode false`.
+
 ### `load_server_icon [fileName.png]`
 
 A console command which loads a specified icon and sets it as the server icon. The icon needs to be a 96x96 PNG file.


### PR DESCRIPTION
Add the sv_stateBagStrictMode ConVar to the list. Removes the outdated section about upcoming state bag filtering and link to the "new" ConVar