### PR TITLE
Add RSG (RedM) to the frameworks list

### DIFF
--- a/content/docs/server-manual/frameworks.md
+++ b/content/docs/server-manual/frameworks.md
@@ -19,6 +19,7 @@ If there's a framework you believe should be included in this list, please submi
 - [ND](https://github.com/ND-Framework/ND_Core) ([Docs](https://ndcore.dev/setup))
 - [QBCore](https://github.com/qbcore-framework/qb-core) ([Docs](https://docs.qbcore.org/qbcore-documentation/))
 - [Qbox](https://github.com/Qbox-project/qbx_core) ([Docs](https://docs.qbox.re/installation))
+- [RSG](https://github.com/Rexshack-RedM/rsg-core) ([Docs](https://rexshack-gaming.gitbook.io/rsg-documentation)) (RedM)
 - [vRP](https://github.com/vRP-framework/vRP) ([Docs](https://vrp-framework.github.io/vRP/))
 - [VORP](https://github.com/VORPCORE/vorp-core-lua) ([Docs](https://docs.vorp-core.com)) (RedM)
 


### PR DESCRIPTION
Adds the RSG framework for RedM to the server manual frameworks list, in alphabetical order between Qbox and vRP and tagged as (RedM). Links point to the rsg-core repository and the official RSG documentation.

Closes #556.