### PR TITLE
Add OpenCore to the frameworks list

### DIFF
--- a/content/docs/server-manual/frameworks.md
+++ b/content/docs/server-manual/frameworks.md
@@ -17,6 +17,7 @@ If there's a framework you believe should be included in this list, please submi
 # Frameworks (Lua) (Alphabetical Order)
 - [ESX](https://github.com/esx-framework/esx-legacy) ([Docs](https://documentation.esx-framework.org/legacy/installation))
 - [ND](https://github.com/ND-Framework/ND_Core) ([Docs](https://ndcore.dev/setup))
+- [OpenCore](https://github.com/newcore-network/opencore) ([Docs](https://opencorejs.dev/)) (TypeScript)
 - [QBCore](https://github.com/qbcore-framework/qb-core) ([Docs](https://docs.qbcore.org/qbcore-documentation/))
 - [Qbox](https://github.com/Qbox-project/qbx_core) ([Docs](https://docs.qbox.re/installation))
 - [vRP](https://github.com/vRP-framework/vRP) ([Docs](https://vrp-framework.github.io/vRP/))


### PR DESCRIPTION
Adds the OpenCore framework to the server manual frameworks list, in alphabetical order between ND and QBCore.

OpenCore is a TypeScript-first framework, so I tagged it as `(TypeScript)` (the way VORP is tagged `(RedM)`). Happy to move it to a separate section instead if you'd prefer to keep the current list Lua-only — just let me know.

- Repository: https://github.com/newcore-network/opencore
- Documentation: https://opencorejs.dev/

Closes #574.