### PR TITLE
Clarify that io.readdir handles are iterated with lines()

### DIFF
--- a/content/docs/developers/sandbox.md
+++ b/content/docs/developers/sandbox.md
@@ -31,6 +31,8 @@ local files3 = io.readdir("/absolute/path/to/resource")
 local files4 = io.readdir("/absolute/path/to/resource/assets")
 ```
 
+Because `io.readdir()` returns a handle rather than a plain table, it cannot be iterated with `ipairs` or `pairs`. Use its `lines()` iterator to read each entry:
+
 ```lua
 local files = io.readdir("@myResource/")
 for file in files:lines() do


### PR DESCRIPTION
The directory listing example in the sandbox docs already used the handle's `lines()` iterator, but never stated that the returned value is a handle (not a plain table) and therefore cannot be iterated with `ipairs` or `pairs`.

This adds a short sentence before the iteration example to prevent that common confusion.

Closes #518.