### PR TITLE
Add light/dark mode support

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,3 +1,6 @@
+// Light/dark Chroma code-highlighting styles
+@import 'td/code-dark';
+
 // Fonts
 @import url(https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;500;600;700&display=swap);
 @import url(https://fonts.googleapis.com/icon?family=Material+Icons+Outlined);

--- a/config.toml
+++ b/config.toml
@@ -13,7 +13,8 @@ disableKinds = ["taxonomy"]
 
 # Highlighting config
 pygmentsCodeFences = true
-pygmentsUseClasses = false
+# Class-based highlighting so Docsy's light/dark Chroma styles apply.
+pygmentsUseClasses = true
 # Use the new Chroma Go highlighter in Hugo.
 pygmentsUseClassic = false
 #pygmentsOptions = "linenos=table"
@@ -79,3 +80,4 @@ weight = 60
 
 [params.ui]
 sidebar_menu_compact = true
+showLightDarkModeMenu = true


### PR DESCRIPTION
I added and tested the dark mode feature with Claude's help. Both dark mode and light mode work correctly on every page. However, the old FiveM theme was set as the default theme; I'm not sure why that happened

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/e62ea3be-1b20-4f4b-bba4-6beea93e4cf7" />

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/969f0a80-335c-4bdb-bc3a-6e5cc3f073a5" />

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/f989cf2f-67ab-4bf0-bf58-4f4ef0c2057b" />

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/66d7e9e1-5df7-4eb8-a7c0-6fdfe1684703" />
