### PR TITLE
add dark mode

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -7,9 +7,11 @@
 @import './shortcodes/steps';
 @import './shortcodes/video';
 
-// Navbar Overrides
+// Light/dark Chroma (tango / onedark)
+@import 'td/code-dark';
+
 .td-navbar {
-  background-color: hsl(226, 23%, 11%);
+  background-color: #121216;
 
   .navbar-brand,
   .navbar-logo,
@@ -41,4 +43,60 @@
 // Always scale to max width
 .td-max-width-on-larger-screens {
   max-width: 100%;
+}
+
+.td-toc #TableOfContents a {
+  &:focus,
+  &:hover,
+  &.active {
+    color: var(--bs-link-color);
+  }
+}
+
+@include color-mode(dark) {
+  color-scheme: dark;
+
+  --bs-body-bg: #121216;
+  --bs-body-bg-rgb: 18, 18, 22;
+  --bs-secondary-bg: #1a1a20;
+  --bs-tertiary-bg: #1e1e26;
+  --bs-body-color: #e8e8ea;
+  --bs-emphasis-color: #fff;
+  --bs-secondary-color: rgba(232, 232, 234, 0.78);
+  --bs-tertiary-color: rgba(232, 232, 234, 0.55);
+  --bs-heading-color: #fff;
+  --bs-border-color: #2a2a32;
+  --bs-link-color: #ff4d7a;
+  --bs-link-hover-color: #ff7aa3;
+  --td-pre-bg: #0e0e12;
+
+  .td-main {
+    background:
+      radial-gradient(ellipse 80% 50% at 50% -10%, rgba(80, 12, 24, 0.35), transparent 55%),
+      var(--bs-body-bg);
+  }
+
+  .td-footer {
+    background-color: #0e0e12;
+    border-top: 1px solid var(--bs-border-color);
+  }
+
+  .td-content {
+    code {
+      color: #ffb3c7;
+    }
+
+    pre code {
+      color: inherit;
+    }
+  }
+
+  .td-box--white {
+    color: var(--bs-body-color);
+    background-color: var(--bs-secondary-bg);
+  }
+
+  .step {
+    background-color: var(--bs-secondary-bg);
+  }
 }

--- a/assets/scss/shortcodes/article-nav.scss
+++ b/assets/scss/shortcodes/article-nav.scss
@@ -1,6 +1,6 @@
 .article-nav {
   display: flex;
-  border-top: 1px solid $border-color;
+  border-top: 1px solid var(--bs-border-color);
   margin-top: 3rem;
   padding-top: 2rem;
   gap: 1rem;
@@ -8,7 +8,7 @@
   .article-nav-link {
     flex: 1;
     text-decoration: none;
-    border: 1px solid $border-color;
+    border: 1px solid var(--bs-border-color);
     padding: 1rem 1.5rem;
 
     &:nth-child(1) { text-align: left; }
@@ -20,7 +20,7 @@
   }
 
   .article-nav-direction {
-    color: $body-secondary-color;
+    color: var(--bs-secondary-color);
     font-size: $font-size-sm;
     text-transform: uppercase;
     margin-bottom: .5rem;
@@ -35,7 +35,7 @@
 
   .article-nav-title {
     font-weight: $font-weight-semibold;
-    color: $body-color;
+    color: var(--bs-body-color);
   }
 
   @include media-breakpoint-down(md) {

--- a/assets/scss/shortcodes/steps.scss
+++ b/assets/scss/shortcodes/steps.scss
@@ -5,7 +5,7 @@
 
 .step {
   margin-bottom: 1.5rem;
-  border: 1px solid $border-color;
+  border: 1px solid var(--bs-border-color);
   overflow: hidden;
   transition: box-shadow .3s ease;
 
@@ -28,7 +28,7 @@
     flex: 0 0 200px;
     min-height: 200px;
     overflow: hidden;
-    background-color: $border-color;
+    background-color: var(--bs-tertiary-bg);
 
     img {
       width: 100%;
@@ -62,7 +62,7 @@
       }
 
       .step-text {
-        color: $body-secondary-color;
+        color: var(--bs-secondary-color);
         margin-bottom: 1rem;
       }
     }
@@ -70,7 +70,8 @@
     .step-button {
       padding: 0.5rem 1rem;
       align-self: flex-start;
-      background-color: rgb(243, 243, 244);
+      background-color: var(--bs-tertiary-bg);
+      color: var(--bs-body-color);
       box-shadow: 0 -2px 0 $primary inset;
       border: none;
 

--- a/config.toml
+++ b/config.toml
@@ -13,7 +13,7 @@ disableKinds = ["taxonomy"]
 
 # Highlighting config
 pygmentsCodeFences = true
-pygmentsUseClasses = false
+pygmentsUseClasses = true
 # Use the new Chroma Go highlighter in Hugo.
 pygmentsUseClassic = false
 #pygmentsOptions = "linenos=table"
@@ -43,6 +43,9 @@ nextPrevInSectionSortOrder = "asc"
 nextPrevSortOrder = "asc"
 
 [markup]
+  [markup.highlight]
+    noClasses = false
+    style = "tango"
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true
@@ -79,3 +82,4 @@ weight = 60
 
 [params.ui]
 sidebar_menu_compact = true
+showLightDarkModeMenu = true

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,0 +1,14 @@
+{{ if .Site.Params.ui.showLightDarkModeMenu -}}
+{{/* Apply stored/OS theme before paint to avoid a light-mode flash. */ -}}
+<script>
+  (() => {
+    const key = 'td-color-theme';
+    const stored = localStorage.getItem(key);
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const theme = stored === 'light' || stored === 'dark'
+      ? stored
+      : (prefersDark ? 'dark' : 'light');
+    document.documentElement.setAttribute('data-bs-theme', theme);
+  })();
+</script>
+{{ end -}}


### PR DESCRIPTION
Enables Docsy's light/dark/auto menu for the Hugo docs site, with a soft dark palette and theme aware shortcodes/code blocks.
Also fixes TOC links going black on hover in dark mode.

## Preview
### Light mode
<img width="2557" height="1438" alt="Screenshot 2026-07-25 080905" src="https://github.com/user-attachments/assets/3e101d7f-232d-4670-9fe3-95aba8665a66" />

### Dark mode
<img width="2560" height="1440" alt="Screenshot 2026-07-25 080924" src="https://github.com/user-attachments/assets/f018e3f4-ada0-41f8-a9ab-d2afeb3f1892" />

<img width="2560" height="1440" alt="Screenshot 2026-07-25 081009" src="https://github.com/user-attachments/assets/985f3940-d52a-4162-9830-f098f4604ebf" />
